### PR TITLE
Remove custom menu from spreadsheet UI

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -989,7 +989,7 @@ function copyOneAdminRowToTarget(adRows, colorHex){
 }
 
 /*****************************
- * القائمة + العرض
+ * العرض (تم إلغاء القائمة)
  *****************************/
 function getAdminSheets(){
   const cfg = getConfig_();
@@ -1007,12 +1007,8 @@ function createAdminSheet(name){
 }
 
 function onOpen() {
-  try {
-    SpreadsheetApp.getUi()
-      .createMenu('أداة البحث المتقدم')
-      .addItem('🚀 فتح الأداة', 'showSidebar')
-      .addToUi();
-  } catch (_) {}
+  // تم إلغاء إنشاء القائمة المخصصة بناءً على الطلب،
+  // لذلك نترك الدالة بدون أي تنفيذ.
 }
 
 function showSidebar() {


### PR DESCRIPTION
## Summary
- remove the spreadsheet onOpen menu setup so no custom menu is added
- update section comment to note that the menu has been removed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfb80c3e64832492bc7c357b3c90d8