### PR TITLE
Preload external sheet data before bulk operations

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -84,11 +84,11 @@ const KEY_ADMIN_ROW_MAP   = "adminRowMap_v7";  // { [id]: [rowIndex,...] }
 const KEY_COLORED_AGENT   = "coloredAgentIds_v7";
 const KEY_COLORED_ADMIN   = "coloredAdminIds_v7";
 const KEY_CORR_MAP        = "salaryCorrMap_v1"; // { "30":29, "88":82, ... }
-const KEY_EXT_AGENT_INDEX   = "extAgentIndex_v1";
-const KEY_EXT_ADMIN_IDSET   = "extAdminIdSet_v1";
-const KEY_EXT_ADMIN_ROW_MAP = "extAdminRowMap_v1";
-const KEY_EXT_COLORED_AGENT = "extColoredAgent_v1";
-const KEY_EXT_COLORED_ADMIN = "extColoredAdmin_v1";
+const KEY_EXT_AGENT_INDEX     = "extAgentIndex_v1";
+const KEY_EXT_ADMIN_IDSET     = "extAdminIdSet_v1";
+const KEY_EXT_ADMIN_ROW_MAP   = "extAdminRowMap_v1";
+const KEY_EXT_COLORED_AGENT   = "extColoredAgent_v1";
+const KEY_EXT_COLORED_ADMIN   = "extColoredAdmin_v1";
 // كاش معلومات الأشخاص:
 const KEY_INFO_ID2GROUP   = "info_id2group_v1"; // { id: groupKey }
 const KEY_INFO_GROUPS     = "info_groups_v1";   // { groupKey: {...} }
@@ -180,91 +180,159 @@ function buildColoredIdSet_(ssId, sheetName) {
   return set;
 }
 
-function loadExternalData_() {
-  const cache = CacheService.getScriptCache();
-  let agentIndex   = cacheGetChunked_(KEY_EXT_AGENT_INDEX,   cache);
-  let adminIdSet   = cacheGetChunked_(KEY_EXT_ADMIN_IDSET,   cache);
-  let adminRowMap  = cacheGetChunked_(KEY_EXT_ADMIN_ROW_MAP, cache);
-  let coloredAgent = cacheGetChunked_(KEY_EXT_COLORED_AGENT, cache);
-  let coloredAdmin = cacheGetChunked_(KEY_EXT_COLORED_ADMIN, cache);
-
-  if (agentIndex && adminIdSet && adminRowMap && coloredAgent && coloredAdmin) {
-    return { agentIndex, adminIdSet, adminRowMap, coloredAgent, coloredAdmin };
+function computeExternalStats_(agentIndex, adminRowMap) {
+  let agentRows = 0;
+  let agentUnique = 0;
+  if (agentIndex && typeof agentIndex === 'object') {
+    const keys = Object.keys(agentIndex);
+    agentUnique = keys.length;
+    for (let i = 0; i < keys.length; i++) {
+      const node = agentIndex[keys[i]];
+      if (node && Array.isArray(node.rows)) {
+        agentRows += node.rows.length;
+      }
+    }
   }
 
-  const links = getExternalSheetLinksFromSettings();
-  const cfg   = getConfig_();
-  const adminInfo = links.admin || {};
-  const agentInfo = links.agent || {};
+  let adminRows = 0;
+  if (adminRowMap && typeof adminRowMap === 'object') {
+    const keys = Object.keys(adminRowMap);
+    for (let i = 0; i < keys.length; i++) {
+      const rows = adminRowMap[keys[i]];
+      if (Array.isArray(rows)) {
+        adminRows += rows.length;
+      }
+    }
+  }
 
-  agentIndex   = {};
-  coloredAgent = {};
+  return { agentRows: agentRows, agentUnique: agentUnique, adminRows: adminRows };
+}
+
+function fetchAndCacheExternalData_(cache, cfg) {
+  const links = getExternalSheetLinksFromSettings();
+  const adminInfo = links.admin || {};
+  if (!adminInfo.url) {
+    throw new Error('⚠️ لم يتم إعداد ملف الإدارة الخارجي.');
+  }
+
+  const adSS = SpreadsheetApp.openByUrl(adminInfo.url);
+  const adSh = getSheetByPreferredName_(adSS, adminInfo.sheetName || cfg.ADMIN_SHEET_NAME);
+  if (!adSh) {
+    throw new Error('⚠️ لم يتم العثور على ورقة الإدارة في الملف الخارجي.');
+  }
+
+  let agentIndex = {};
+  let coloredAgent = {};
+  const agentInfo = links.agent || {};
   if (agentInfo.url) {
     const agSS = SpreadsheetApp.openByUrl(agentInfo.url);
     const agSh = getSheetByPreferredName_(agSS, agentInfo.sheetName || cfg.AGENT_SHEET_NAME);
-    if (!agSh) throw new Error('⚠️ لم يتم العثور على ورقة الوكيل في الملف الخارجي.');
+    if (!agSh) {
+      throw new Error('⚠️ لم يتم العثور على ورقة الوكيل في الملف الخارجي.');
+    }
     const lr = agSh.getLastRow();
     if (lr > 0) {
-      const colA = agSh.getRange(1,1,lr,1).getValues().flat();
-      const colB = agSh.getRange(1,2,lr,1).getValues().flat();
-      const colC = agSh.getRange(1,3,lr,1).getValues().flat();
+      const colA = agSh.getRange(1, 1, lr, 1).getValues().flat();
+      const colB = agSh.getRange(1, 2, lr, 1).getValues().flat();
+      const colC = agSh.getRange(1, 3, lr, 1).getValues().flat();
       agentIndex = buildAgentIndex_(colA, colB, colC);
       try {
-        const bgs = agSh.getRange(1,1,lr,1).getBackgrounds().flat();
-        for (let i=0;i<colA.length;i++){
-          const id = String(colA[i]||'').trim();
+        const bgs = agSh.getRange(1, 1, lr, 1).getBackgrounds().flat();
+        for (let i = 0; i < colA.length; i++) {
+          const id = String(colA[i] || '').trim();
           if (!id) continue;
-          const c = String(bgs[i]||'').toLowerCase();
+          const c = String(bgs[i] || '').toLowerCase();
           if (c && c !== '#ffffff' && c !== 'white' && c !== 'transparent') {
             coloredAgent[id] = 1;
           }
         }
-      } catch(_) {}
+      } catch (_) {}
     }
   }
 
-  adminIdSet   = {};
-  adminRowMap  = {};
-  coloredAdmin = {};
-  if (adminInfo.url) {
-    const adSS = SpreadsheetApp.openByUrl(adminInfo.url);
-    const adSh = getSheetByPreferredName_(adSS, adminInfo.sheetName || cfg.ADMIN_SHEET_NAME);
-    if (!adSh) throw new Error('⚠️ لم يتم العثور على ورقة الإدارة في الملف الخارجي.');
-    const lr = adSh.getLastRow();
-    if (lr > 0) {
-      const colA = adSh.getRange(1,1,lr,1).getValues().flat();
-      try {
-        const bgs = adSh.getRange(1,1,lr,1).getBackgrounds().flat();
-        for (let i=0;i<colA.length;i++){
-          const id = String(colA[i]||'').trim();
-          if (!id) continue;
-          adminIdSet[id] = 1;
-          if (!adminRowMap[id]) adminRowMap[id] = [];
-          adminRowMap[id].push(i+1);
-          const c = String(bgs[i]||'').toLowerCase();
-          if (c && c !== '#ffffff' && c !== 'white' && c !== 'transparent') {
-            coloredAdmin[id] = 1;
-          }
-        }
-      } catch(_) {
-        for (let i=0;i<colA.length;i++){
-          const id = String(colA[i]||'').trim();
-          if (!id) continue;
-          adminIdSet[id] = 1;
-          if (!adminRowMap[id]) adminRowMap[id] = [];
-          adminRowMap[id].push(i+1);
+  const adminIdSet = {};
+  const adminRowMap = {};
+  const coloredAdmin = {};
+  const adLr = adSh.getLastRow();
+  if (adLr > 0) {
+    const colA = adSh.getRange(1, 1, adLr, 1).getValues().flat();
+    let bgs = null;
+    try {
+      bgs = adSh.getRange(1, 1, adLr, 1).getBackgrounds().flat();
+    } catch (_) {}
+    for (let i = 0; i < colA.length; i++) {
+      const id = String(colA[i] || '').trim();
+      if (!id) continue;
+      adminIdSet[id] = 1;
+      if (!adminRowMap[id]) adminRowMap[id] = [];
+      adminRowMap[id].push(i + 1);
+      if (bgs) {
+        const c = String(bgs[i] || '').toLowerCase();
+        if (c && c !== '#ffffff' && c !== 'white' && c !== 'transparent') {
+          coloredAdmin[id] = 1;
         }
       }
     }
   }
 
-  cachePutChunked_(KEY_EXT_AGENT_INDEX,   agentIndex,   cache);
-  cachePutChunked_(KEY_EXT_ADMIN_IDSET,   adminIdSet,   cache);
-  cachePutChunked_(KEY_EXT_ADMIN_ROW_MAP, adminRowMap,  cache);
+  cachePutChunked_(KEY_EXT_AGENT_INDEX, agentIndex, cache);
+  cachePutChunked_(KEY_EXT_ADMIN_IDSET, adminIdSet, cache);
+  cachePutChunked_(KEY_EXT_ADMIN_ROW_MAP, adminRowMap, cache);
   cachePutChunked_(KEY_EXT_COLORED_AGENT, coloredAgent, cache);
   cachePutChunked_(KEY_EXT_COLORED_ADMIN, coloredAdmin, cache);
 
-  return { agentIndex, adminIdSet, adminRowMap, coloredAgent, coloredAdmin };
+  const stats = computeExternalStats_(agentIndex, adminRowMap);
+
+  return {
+    agentIndex: agentIndex,
+    adminIdSet: adminIdSet,
+    adminRowMap: adminRowMap,
+    coloredAgent: coloredAgent,
+    coloredAdmin: coloredAdmin,
+    stats: stats,
+    ready: true,
+    fromCache: false
+  };
+}
+
+function loadExternalData_(options) {
+  options = options || {};
+  const cache = CacheService.getScriptCache();
+  let agentIndex = cacheGetChunked_(KEY_EXT_AGENT_INDEX, cache);
+  let adminIdSet = cacheGetChunked_(KEY_EXT_ADMIN_IDSET, cache);
+  let adminRowMap = cacheGetChunked_(KEY_EXT_ADMIN_ROW_MAP, cache);
+  let coloredAgent = cacheGetChunked_(KEY_EXT_COLORED_AGENT, cache);
+  let coloredAdmin = cacheGetChunked_(KEY_EXT_COLORED_ADMIN, cache);
+
+  const ready = !!(agentIndex && adminIdSet && adminRowMap && coloredAgent && coloredAdmin);
+  if (ready && !options.forceReload) {
+    return {
+      agentIndex: agentIndex,
+      adminIdSet: adminIdSet,
+      adminRowMap: adminRowMap,
+      coloredAgent: coloredAgent,
+      coloredAdmin: coloredAdmin,
+      stats: computeExternalStats_(agentIndex, adminRowMap),
+      ready: true,
+      fromCache: true
+    };
+  }
+
+  if (options.fromCacheOnly) {
+    return {
+      agentIndex: agentIndex || {},
+      adminIdSet: adminIdSet || {},
+      adminRowMap: adminRowMap || {},
+      coloredAgent: coloredAgent || {},
+      coloredAdmin: coloredAdmin || {},
+      stats: ready ? computeExternalStats_(agentIndex, adminRowMap) : { agentRows: 0, agentUnique: 0, adminRows: 0 },
+      ready: ready,
+      fromCache: !!ready
+    };
+  }
+
+  const cfg = getConfig_();
+  return fetchAndCacheExternalData_(cache, cfg);
 }
 
 /*****************************
@@ -515,9 +583,19 @@ function loadDataIntoCache() {
     let adminRows = 0;
     for (const id in adminRowMap) adminRows += (adminRowMap[id] ? adminRowMap[id].length : 0);
 
+    let externalSummary = '';
+    try {
+      const ext = loadExternalData_({ forceReload: true });
+      if (ext && ext.ready && ext.stats) {
+        externalSummary = ' — الخارجي: الوكيل ' + ext.stats.agentRows + ' صف / ' + ext.stats.agentUnique + ' ID فريد — الإدارة: ' + ext.stats.adminRows + ' صف.';
+      }
+    } catch (extErr) {
+      externalSummary = ' — ⚠️ فشل تحميل الخارجي: ' + (extErr && extErr.message ? extErr.message : String(extErr || ''));
+    }
+
     return {
       success:true,
-      message:'تم التحميل ✓ — الوكيل: '+agentRows+' صف / '+agentUnique+' ID فريد — الإدارة: '+adminRows+' صف.'
+      message:'تم التحميل ✓ — الوكيل: '+agentRows+' صف / '+agentUnique+' ID فريد — الإدارة: '+adminRows+' صف.' + externalSummary
     };
   } catch (e) {
     return { success:false, message:'خطأ: ' + e.message };
@@ -1340,10 +1418,9 @@ function createExternalSheetIfMissing(name) {
 }
 
 function normalizeBulkScope_(scope) {
-  const s = String(scope || 'both').trim().toLowerCase();
+  const s = String(scope || '').trim().toLowerCase();
   if (s === 'agent') return 'agent';
-  if (s === 'all') return 'all';
-  return 'both';
+  return 'all';
 }
 
 function buildBulkContext_(scope) {
@@ -1362,16 +1439,26 @@ function buildBulkContext_(scope) {
     coloredAgent: coloredAgentRaw || {},
     coloredAdmin: coloredAdminRaw || {},
     corrMap:      corrMapRaw      || {},
-    hasCoreData:  !!(agentIndexRaw && adminIdSetRaw && coloredAgentRaw && coloredAdminRaw)
+    hasCoreData:  !!(agentIndexRaw && adminIdSetRaw && coloredAgentRaw && coloredAdminRaw),
+    hasExternalData: false
   };
 
   if (scope === 'all') {
-    const ext = loadExternalData_();
-    ctx.extAgentIndex   = ext.agentIndex   || {};
-    ctx.extAdminIdSet   = ext.adminIdSet   || {};
-    ctx.extAdminRowMap  = ext.adminRowMap  || {};
-    ctx.extColoredAgent = ext.coloredAgent || {};
-    ctx.extColoredAdmin = ext.coloredAdmin || {};
+    const ext = loadExternalData_({ fromCacheOnly: true });
+    if (ext && ext.ready) {
+      ctx.extAgentIndex   = ext.agentIndex   || {};
+      ctx.extAdminIdSet   = ext.adminIdSet   || {};
+      ctx.extAdminRowMap  = ext.adminRowMap  || {};
+      ctx.extColoredAgent = ext.coloredAgent || {};
+      ctx.extColoredAdmin = ext.coloredAdmin || {};
+      ctx.hasExternalData = true;
+    } else {
+      ctx.extAgentIndex   = {};
+      ctx.extAdminIdSet   = {};
+      ctx.extAdminRowMap  = {};
+      ctx.extColoredAgent = {};
+      ctx.extColoredAdmin = {};
+    }
   }
 
   return ctx;
@@ -1490,6 +1577,9 @@ function bulkSearchExact(ids, discount, scope) {
     if (!ctx.hasCoreData) {
       throw new Error('⚠️ حمّل البيانات أولًا من زر "تحميل البيانات".');
     }
+    if (scope === 'all' && !ctx.hasExternalData) {
+      throw new Error('⚠️ حمّل البيانات الخارجية أولًا من زر "تحميل البيانات".');
+    }
 
     const results = [];
     for (let i = 0; i < list.length; i++) {
@@ -1538,6 +1628,9 @@ function bulkExecuteExact(ids, config) {
     if (!ctx.hasCoreData) {
       throw new Error('⚠️ حمّل البيانات أولًا من زر "تحميل البيانات".');
     }
+    if (includeExternal && !ctx.hasExternalData) {
+      throw new Error('⚠️ حمّل البيانات الخارجية أولًا من زر "تحميل البيانات".');
+    }
     const cfg = getConfig_();
 
     const agSS = SpreadsheetApp.openById(cfg.AGENT_SHEET_ID);
@@ -1582,8 +1675,8 @@ function bulkExecuteExact(ids, config) {
     let extTargetSh = null;
     let extAdminColorBucket = null;
     let extAgentColorBucket = null;
-    const extTargetIdSet = Object.create(null);
-    const extRecentCopied = Object.create(null);
+    let extTargetColorBucket = null;
+    const extTargetIdRows = Object.create(null);
     let extColoredAdmin = {};
     let extColoredAgent = {};
     let copiedExternal = 0;
@@ -1612,12 +1705,15 @@ function bulkExecuteExact(ids, config) {
 
       if (externalSheetName) {
         extTargetSh = extAdSS.getSheetByName(externalSheetName) || extAdSS.insertSheet(externalSheetName);
+        extTargetColorBucket = Object.create(null);
         const lr = extTargetSh.getLastRow();
         if (lr > 0) {
           const colA = extTargetSh.getRange(1, 1, lr, 1).getDisplayValues();
           for (let i = 0; i < lr; i++) {
             const val = String(colA[i][0] || '').trim();
-            if (val) extTargetIdSet[val] = 1;
+            if (!val) continue;
+            if (!extTargetIdRows[val]) extTargetIdRows[val] = [];
+            extTargetIdRows[val].push(i + 1);
           }
         }
       }
@@ -1637,18 +1733,12 @@ function bulkExecuteExact(ids, config) {
       return res;
     };
 
-    const copyToExternalTarget = (colorHex, localRows, externalRows) => {
-      if (!includeExternal || !extTargetSh) return { copied: 0, skipped: 0 };
-      let res = { copied: 0, skipped: 0 };
-      if (externalRows.length) {
-        res = copyAdminRowOnce_(extAdMainSh, externalRows, extTargetSh, colorHex, extTargetIdSet, extRecentCopied);
-      }
-      if (!res.copied && localRows.length) {
-        const r2 = copyAdminRowOnce_(adSh, localRows, extTargetSh, colorHex, extTargetIdSet, extRecentCopied);
-        res.copied += r2.copied;
-        res.skipped += r2.skipped;
-      }
-      return res;
+    const colorExternalTarget = (colorHex, id) => {
+      if (!includeExternal || !extTargetSh || !colorHex) return false;
+      const rows = extTargetIdRows[id];
+      if (!rows || !rows.length) return false;
+      queueColorRows_(extTargetColorBucket, colorHex, rows);
+      return true;
     };
 
     list.forEach(id => {
@@ -1694,10 +1784,9 @@ function bulkExecuteExact(ids, config) {
           skippedLocal += resLocal.skipped;
 
           if (includeExternal) {
-            const resExt = copyToExternalTarget(adminColor, adRowsLocal, adRowsExt);
-            if (resExt.copied) markColored();
-            copiedExternal += resExt.copied;
-            skippedExternal += resExt.skipped;
+            if (colorExternalTarget(adminColor, id)) {
+              markColored();
+            }
           }
         }
       }
@@ -1732,10 +1821,9 @@ function bulkExecuteExact(ids, config) {
           skippedLocal += resLocal.skipped;
 
           if (includeExternal) {
-            const resExt = copyToExternalTarget(withdrawColor, adRowsLocal, adRowsExt);
-            if (resExt.copied) markColored();
-            copiedExternal += resExt.copied;
-            skippedExternal += resExt.skipped;
+            if (colorExternalTarget(withdrawColor, id)) {
+              markColored();
+            }
           }
         }
       }
@@ -1757,6 +1845,11 @@ function bulkExecuteExact(ids, config) {
       if (extAdminColorBucket && extAdMainSh) {
         for (const color in extAdminColorBucket) {
           colorRowsFast_(extAdMainSh, extAdminColorBucket[color], color);
+        }
+      }
+      if (extTargetColorBucket && extTargetSh) {
+        for (const color in extTargetColorBucket) {
+          colorRowsFast_(extTargetSh, extTargetColorBucket[color], color);
         }
       }
     }


### PR DESCRIPTION
## Summary
- load and cache the external agent/admin sheets during the standard data preload so cached maps and stats are ready
- rely on cached external indices when building bulk contexts and require the external snapshot to exist before running bulk search or execute
- default bulk scope to include external data so group execution mirrors the advanced single-search flow by default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff37b68008324a46b72c9d6f2ae4e