### PR TITLE
Improve nearby ID suggestions visibility

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -81,6 +81,19 @@
     #searchCard{background:var(--surface);border-radius:22px;box-shadow:none;border:1px solid rgba(255,255,255,.05);}
     #searchCard button{min-width:160px;}
     #searchCard .column button{width:100%;}
+    #nearbyBox{display:none;margin-top:12px;padding:14px 16px;border-radius:18px;background:rgba(15,23,34,0.9);border:1px solid rgba(43,255,168,.28);box-shadow:0 18px 42px rgba(14,146,112,.28);backdrop-filter:blur(18px);transition:transform .18s ease,opacity .18s ease;}
+    #nearbyBox.show{display:block;opacity:1;transform:translateY(0);}
+    #nearbyBox:not(.show){opacity:0;transform:translateY(4px);}
+    .nearby-header{font-size:12px;font-weight:800;color:var(--muted);letter-spacing:.4px;margin-bottom:10px;}
+    .nearby-list{display:flex;flex-direction:column;gap:8px;}
+    .nearby-item{border:none;display:flex;align-items:center;justify-content:space-between;gap:14px;padding:11px 14px;border-radius:14px;background:rgba(43,255,168,.1);color:var(--text);font-weight:700;text-align:right;cursor:pointer;transition:background .18s ease,border .18s ease,transform .18s ease;box-shadow:0 12px 28px rgba(12,70,54,.25);border:1px solid rgba(43,255,168,.18);}
+    .nearby-item:hover{background:rgba(43,255,168,.18);border-color:rgba(43,255,168,.35);}
+    .nearby-item:active{transform:scale(.985);}
+    .nearby-item--primary{background:linear-gradient(135deg,rgba(43,255,168,.24),rgba(56,189,248,.24));border-color:rgba(56,189,248,.42);box-shadow:0 14px 34px rgba(43,255,168,.28);}
+    .nearby-item--primary:hover{background:linear-gradient(135deg,rgba(43,255,168,.32),rgba(56,189,248,.32));}
+    .nearby-id{font-size:16px;font-variant-numeric:tabular-nums;color:var(--text-strong);}
+    .nearby-status{font-size:13px;color:var(--muted);margin-inline-start:auto;}
+    .nearby-diff{font-size:11px;color:rgba(226,232,240,.75);min-width:42px;text-align:left;direction:ltr;}
     #advCard{background:var(--surface);border-radius:26px;border:1px solid rgba(255,255,255,.05);box-shadow:none;display:flex;flex-direction:column;gap:16px;}
     #advCard .row{gap:10px;}
     #advCard select{background:var(--surface-strong);}
@@ -218,6 +231,10 @@
         <div class="column stretch">
           <input id="idInput" type="text" placeholder="أدخل ID هنا" autocomplete="off" inputmode="numeric">
           <button id="pasteSearchBtn" class="btn-blue" type="button">لصق ثم بحث</button>
+        </div>
+        <div id="nearbyBox">
+          <div class="nearby-header">أقرب IDs متاحة</div>
+          <div id="nearbyList" class="nearby-list"></div>
         </div>
         <div class="row" style="margin-top:8px;justify-content:space-between;">
           <div id="pasteHint" class="muted"></div>
@@ -461,6 +478,8 @@
     const idInput        = document.getElementById('idInput');
     const pasteSearchBtn = document.getElementById('pasteSearchBtn');
     const pasteHint      = document.getElementById('pasteHint');
+    const nearbyBox      = document.getElementById('nearbyBox');
+    const nearbyList     = document.getElementById('nearbyList');
 
     const resultsBox  = document.getElementById('resultsBox');
     const statusBadge = document.getElementById('statusBadge');
@@ -622,6 +641,7 @@ const advCard  = document.getElementById('advCard');
 
     // حالة
     let localMap = null;
+    let sortedLocalIds = [];
     let lastResult = null;
     let lastProfileIds = [];
     let lastBaseId = '';
@@ -697,6 +717,97 @@ const advCard  = document.getElementById('advCard');
     };
 
     const isMobileLayout = () => window.matchMedia('(max-width: 1200px)').matches;
+
+    function rebuildSortedLocalIds(){
+      if (!localMap || typeof localMap !== 'object'){ sortedLocalIds = []; return; }
+      const keys = Object.keys(localMap)
+        .filter(id => /^\d+$/.test(id));
+      keys.sort((a,b) => Number(a) - Number(b));
+      sortedLocalIds = keys;
+    }
+
+    function clearNearbySuggestions(){
+      if (!nearbyBox || !nearbyList) return;
+      nearbyList.innerHTML = '';
+      nearbyBox.classList.remove('show');
+      nearbyBox.style.display = 'none';
+    }
+
+    function getNearbySuggestions(id, limit = 5){
+      if (!sortedLocalIds.length) return [];
+      const target = Number(id);
+      if (!Number.isFinite(target)) return [];
+
+      let lo = 0;
+      let hi = sortedLocalIds.length;
+      while (lo < hi){
+        const mid = (lo + hi) >> 1;
+        const value = Number(sortedLocalIds[mid]);
+        if (value < target) lo = mid + 1;
+        else hi = mid;
+      }
+
+      let left = lo - 1;
+      let right = lo;
+      const picks = [];
+      const seen = new Set();
+
+      while (picks.length < limit && (left >= 0 || right < sortedLocalIds.length)){
+        const leftDiff = left >= 0 ? Math.abs(Number(sortedLocalIds[left]) - target) : Infinity;
+        const rightDiff = right < sortedLocalIds.length ? Math.abs(Number(sortedLocalIds[right]) - target) : Infinity;
+
+        if (leftDiff <= rightDiff){
+          const candidate = sortedLocalIds[left--];
+          if (candidate !== id && !seen.has(candidate)){
+            seen.add(candidate);
+            picks.push({ id: candidate, diff: leftDiff });
+          }
+        } else {
+          const candidate = sortedLocalIds[right++];
+          if (candidate !== id && !seen.has(candidate)){
+            seen.add(candidate);
+            picks.push({ id: candidate, diff: rightDiff });
+          }
+        }
+      }
+
+      return picks.map(entry => {
+        const base = buildLocalResult(entry.id);
+        return Object.assign({ diff: entry.diff }, base);
+      }).filter(item => item && item.status && item.status !== 'غير موجود');
+    }
+
+    function renderNearbySuggestions(id){
+      if (!nearbyBox || !nearbyList) return;
+      const cleanId = String(id || '').trim();
+      if (!cleanId){ clearNearbySuggestions(); return; }
+
+      const suggestions = getNearbySuggestions(cleanId, 5);
+      if (!suggestions.length){ clearNearbySuggestions(); return; }
+
+      nearbyList.innerHTML = '';
+      suggestions.forEach((suggestion, index) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'nearby-item' + (index === 0 ? ' nearby-item--primary' : '');
+        const diffLabel = Number.isFinite(suggestion.diff) && suggestion.diff > 0
+          ? `±${suggestion.diff}`
+          : '';
+        btn.innerHTML = `
+          <span class="nearby-status">${suggestion.status || ''}</span>
+          <span class="nearby-id">${suggestion.id || ''}</span>
+          <span class="nearby-diff">${diffLabel}</span>
+        `;
+        btn.addEventListener('click', () => {
+          idInput.value = suggestion.id || '';
+          doSearch();
+        });
+        nearbyList.appendChild(btn);
+      });
+
+      nearbyBox.style.display = 'block';
+      nearbyBox.classList.add('show');
+    }
 
     function markJustColored(ids, mode){
       const arr = Array.isArray(ids) ? ids : [ids];
@@ -1391,6 +1502,7 @@ const advCard  = document.getElementById('advCard');
                 return;
               }
               localMap = res.map || null;
+              rebuildSortedLocalIds();
               const st = res.stats || {};
               loadNote.textContent = `${baseMsg} | محلي: ${st.agentRows||0} صف / ${st.agentUnique||0} ID.`;
               setLoadBtnState(true);
@@ -1515,6 +1627,9 @@ const advCard  = document.getElementById('advCard');
     });
     idInput.addEventListener('paste', ()=> setTimeout(doSearch, 0));
     idInput.addEventListener('keyup', e=>{ if (e.key === 'Enter') doSearch(); });
+    idInput.addEventListener('input', ()=>{
+      if (!idInput.value.trim()) clearNearbySuggestions();
+    });
 
     /******** رندر النتائج ********/
     function clearDupUI(){
@@ -1867,77 +1982,87 @@ const advCard  = document.getElementById('advCard');
       };
     }
 
-    function doSearch(){
-  const id = String(idInput.value||'').trim();
-  if (!id){
-    applyBadges('غير موجود', null, false);
-    amountText.textContent = '—';
-    multiText.textContent  = '';
-    if (discountInfo){
-      discountInfo.textContent = '';
-      discountInfo.style.display = 'none';
-    }
-    personNote.textContent = '—';
-    personMsg.value = '';
-    clearDupUI();
-    return;
-  }
-
-  saveLastId(id);
-  lastBaseId = id;
-  renderLoading(); // أبقِ "جارٍ البحث…" كافتراضي
-
-  const hasLocal = !!(localMap && Object.prototype.hasOwnProperty.call(localMap, id));
-  if (hasLocal){
-    // إذا موجود بالوكيل: أعرض محليًا فورًا (وكالة/سحب وكالة/راتبين)
-    const node = localMap[id];
-    const inAdmin   = !!node.inAdmin;
-    const rowsCount = Number(node.rowsCount||0);
-    const total     = Number(node.sum||0);
-    const salaries  = Array.isArray(node.salaries) ? node.salaries.map(Number) : [];
-    let status;
-    if (rowsCount > 0) status = inAdmin ? ((rowsCount>1)? 'سحب وكالة - راتبين':'سحب وكالة')
-                                        : ((rowsCount>1)? 'راتبين':'وكالة');
-    else status = 'غير موجود';
-
-    let isDuplicate=false, duplicateLabel=null;
-    if (node.aCol && node.dCol) { isDuplicate = true; duplicateLabel = 'مكرر'; }
-    else if (node.aCol)         { isDuplicate = true; duplicateLabel = 'مكرر وكالة فقط'; }
-    else if (node.dCol)         { isDuplicate = true; duplicateLabel = 'مكرر ادارة فقط'; }
-
-    renderResult({
-      status,
-      totalSalary: total.toFixed(2),
-      salaries,
-      names: (Array.isArray(node.names) ? node.names : []),
-      name: (Array.isArray(node.names) && node.names.length ? String(node.names[0]||'').trim() : ''),
-      discountAmount: '0.00',
-      salaryAfterDiscount: total.toFixed(2),
-      id,
-      isDuplicate,
-      duplicateLabel
-    });
-  }
-  // إذا غير موجود محليًا (قد يكون "إدارة فقط"): لا نعرض "غير موجود" — ننتظر رد السيرفر.
-
-  const mySeq = (++window.__qseq || (window.__qseq=1));
-  const pct = clampDiscountValue(discountInput?.value);
-
-  google.script.run
-    .withSuccessHandler(res=>{
-      if (mySeq !== window.__qseq) return; // تجاهل الردود المتأخرة
-      if (!res || res.status === 'error'){
-        if (res && res.message) renderResult({ status:'error', message: res.message });
-        return;
+  function doSearch(){
+    const id = String(idInput.value||'').trim();
+    if (!id){
+      applyBadges('غير موجود', null, false);
+      amountText.textContent = '—';
+      multiText.textContent  = '';
+      if (discountInfo){
+        discountInfo.textContent = '';
+        discountInfo.style.display = 'none';
       }
-      renderResult(res);
-      renderPersonCard(id);
-    })
-    .withFailureHandler(err=>{
-      if (err && err.message) renderResult({ status:'error', message: err.message });
-    })
-    .searchId(id, pct);
-}
+      personNote.textContent = '—';
+      personMsg.value = '';
+      clearDupUI();
+      clearNearbySuggestions();
+      return;
+    }
+
+    saveLastId(id);
+    lastBaseId = id;
+    renderLoading(); // أبقِ "جارٍ البحث…" كافتراضي
+    clearNearbySuggestions();
+
+    const hasLocal = !!(localMap && Object.prototype.hasOwnProperty.call(localMap, id));
+    if (hasLocal){
+      // إذا موجود بالوكيل: أعرض محليًا فورًا (وكالة/سحب وكالة/راتبين)
+      const node = localMap[id];
+      const inAdmin   = !!node.inAdmin;
+      const rowsCount = Number(node.rowsCount||0);
+      const total     = Number(node.sum||0);
+      const salaries  = Array.isArray(node.salaries) ? node.salaries.map(Number) : [];
+      let status;
+      if (rowsCount > 0) status = inAdmin ? ((rowsCount>1)? 'سحب وكالة - راتبين':'سحب وكالة')
+                                          : ((rowsCount>1)? 'راتبين':'وكالة');
+      else status = 'غير موجود';
+
+      let isDuplicate=false, duplicateLabel=null;
+      if (node.aCol && node.dCol) { isDuplicate = true; duplicateLabel = 'مكرر'; }
+      else if (node.aCol)         { isDuplicate = true; duplicateLabel = 'مكرر وكالة فقط'; }
+      else if (node.dCol)         { isDuplicate = true; duplicateLabel = 'مكرر ادارة فقط'; }
+
+      renderResult({
+        status,
+        totalSalary: total.toFixed(2),
+        salaries,
+        names: (Array.isArray(node.names) ? node.names : []),
+        name: (Array.isArray(node.names) && node.names.length ? String(node.names[0]||'').trim() : ''),
+        discountAmount: '0.00',
+        salaryAfterDiscount: total.toFixed(2),
+        id,
+        isDuplicate,
+        duplicateLabel
+      });
+      clearNearbySuggestions();
+    }
+    // إذا غير موجود محليًا (قد يكون "إدارة فقط"): لا نعرض "غير موجود" — ننتظر رد السيرفر.
+    else {
+      renderNearbySuggestions(id);
+    }
+
+    const mySeq = (++window.__qseq || (window.__qseq=1));
+    const pct = clampDiscountValue(discountInput?.value);
+
+    google.script.run
+      .withSuccessHandler(res=>{
+        if (mySeq !== window.__qseq) return; // تجاهل الردود المتأخرة
+        if (!res || res.status === 'error'){
+          if (res && res.message) renderResult({ status:'error', message: res.message });
+          renderNearbySuggestions(id);
+          return;
+        }
+        renderResult(res);
+        if (res.status === 'غير موجود') renderNearbySuggestions(id);
+        else clearNearbySuggestions();
+        renderPersonCard(id);
+      })
+      .withFailureHandler(err=>{
+        if (err && err.message) renderResult({ status:'error', message: err.message });
+        renderNearbySuggestions(id);
+      })
+      .searchId(id, pct);
+  }
 
     // تحديث الخصم دون اتصالات
     (function(){


### PR DESCRIPTION
## Summary
- add a dedicated "nearby IDs" panel below the search input with high-contrast styling
- compute and render nearby IDs from the local cache to give quick access when a search misses
- clear or refresh the nearby list as searches run or results arrive to keep the UI in sync

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e01ad4be148324ba27af36b5eb6a51