### PR TITLE
Keep copy buttons active during bulk execution

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -911,12 +911,11 @@ const advCard  = document.getElementById('advCard');
     function setBulkBusy(flag){
       bulkBusy = !!flag;
       const disabled = bulkBusy;
-      [bulkPasteBtn, bulkExecuteBtn, bulkCopyAllBtn, bulkCopySalaryBtn, bulkResetBtn,
+      [bulkPasteBtn, bulkExecuteBtn,
         bulkScope, bulkTargetSheet, bulkRefreshSheets, bulkNewSheet, bulkCreateSheet,
         bulkExternalTargetSheet, bulkExternalRefreshSheets, bulkExternalNewSheet, bulkExternalCreateSheet,
         bulkAdminColor, bulkWithdrawColor, bulkDiscount, bulkIdsInput]
-        .forEach(el => { if (el) el.disabled = disabled && el !== bulkResetBtn; });
-      if (bulkResetBtn) bulkResetBtn.disabled = disabled;
+        .forEach(el => { if (el) el.disabled = disabled; });
     }
 
     function updateBulkProgress(done, total, label){
@@ -930,10 +929,12 @@ const advCard  = document.getElementById('advCard');
 
     function updateBulkButtons(){
       const hasIds = bulkIds.length > 0;
+      const hasCopyableResults = bulkResults.length > 0;
       if (bulkPasteBtn) bulkPasteBtn.disabled = bulkBusy;
       if (bulkExecuteBtn) bulkExecuteBtn.disabled = !hasIds || !bulkAnalyzed || bulkBusy;
-      if (bulkCopyAllBtn) bulkCopyAllBtn.disabled = !bulkExecuted || bulkBusy;
-      if (bulkCopySalaryBtn) bulkCopySalaryBtn.disabled = !bulkExecuted || bulkBusy;
+      if (bulkCopyAllBtn) bulkCopyAllBtn.disabled = !hasCopyableResults;
+      if (bulkCopySalaryBtn) bulkCopySalaryBtn.disabled = !hasCopyableResults;
+      if (bulkResetBtn) bulkResetBtn.disabled = bulkBusy || !bulkExecuted;
     }
 
     function renderBulkResults(){
@@ -1341,10 +1342,11 @@ const advCard  = document.getElementById('advCard');
     }
 
     async function copyBulk(mode){
-      if (!bulkExecuted || !bulkResults.length) {
+      if (!bulkResults.length) {
         if (bulkStatusText) bulkStatusText.textContent = '⚠️ نفّذ التحليل والتطبيق أولًا.';
         return;
       }
+      const copyingDuringRun = bulkBusy || !bulkExecuted;
       const discountPct = Math.max(0, Math.min(100, Number(bulkDiscount?.value) || 0));
       const discountApplied = discountPct > 0;
       const rows = bulkResults.map(res => {
@@ -1355,9 +1357,17 @@ const advCard  = document.getElementById('advCard');
         return [res.id || '', salaryStr, res.state || ''].join('\t');
       });
       const text = rows.join('\n');
+      const successMessage = copyingDuringRun
+        ? 'ℹ️ تم النسخ من آخر نتائج مكتملة (لا تزال العملية الحالية جارية).'
+        : '✅ تم النسخ إلى الحافظة.';
+      const fallbackMessage = copyingDuringRun
+        ? 'ℹ️ تم النسخ (وضع احتياطي) من آخر نتائج مكتملة أثناء استمرار العملية الحالية.'
+        : '✅ تم النسخ (وضع احتياطي).';
       try {
         await navigator.clipboard.writeText(text);
-        if (bulkStatusText) bulkStatusText.textContent = '✅ تم النسخ إلى الحافظة.';
+        if (bulkStatusText) {
+          bulkStatusText.textContent = successMessage;
+        }
       } catch (err) {
         const helper = document.createElement('textarea');
         helper.style.position = 'fixed';
@@ -1368,7 +1378,7 @@ const advCard  = document.getElementById('advCard');
         helper.select();
         try {
           document.execCommand('copy');
-          if (bulkStatusText) bulkStatusText.textContent = '✅ تم النسخ (وضع احتياطي).';
+          if (bulkStatusText) bulkStatusText.textContent = fallbackMessage;
         } catch (e2) {
           if (bulkStatusText) bulkStatusText.textContent = `⚠️ انسخ يدويًا: ${e2?.message || e2}`;
         }


### PR DESCRIPTION
## Summary
- keep the bulk copy buttons enabled as long as there are results even while a new execution is running
- allow copying previous results during a run and update the status messaging to clarify when copies come from the last completed batch

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3052da0008324bf9c3cd6f6d9aa59