### PR TITLE
Include duplicate labels when copying bulk results

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -1354,7 +1354,9 @@ const advCard  = document.getElementById('advCard');
         const salaryVal = Number(baseSalaryRaw || 0);
         const salaryStr = salaryVal.toFixed(2);
         if (mode === 'salary') return salaryStr;
-        return [res.id || '', salaryStr, res.state || ''].join('\t');
+        const stateText = res.state || '';
+        const duplicateText = res.duplicateLabel ? `${stateText ? ' - ' : ''}${res.duplicateLabel}` : '';
+        return [res.id || '', salaryStr, `${stateText}${duplicateText}`.trim()].join('\t');
       });
       const text = rows.join('\n');
       const successMessage = copyingDuringRun


### PR DESCRIPTION
## Summary
- append the duplicate status label to the state text when copying bulk tool results so duplicate entries are preserved in the clipboard output

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3591eebe08324bc7e98e90abc7b63