### PR TITLE
Ensure settings sections use column K labels

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,32 +1,189 @@
 /*****************************
  * إعدادات عامة + قراءة Settings
  *****************************/
-function getConfig_() {
+const PROP_ACTIVE_SECTION = 'activeSectionRow_v1';
+const PROP_CACHE_SECTION  = 'cacheSectionRow_v1';
+
+function readSettingsSections_() {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const sh = ss.getSheetByName("Settings");
-  if (!sh) throw new Error("❌ لم يتم العثور على ورقة Settings. أنشئ ورقة باسم Settings وضع القيم في الصف 2.");
+  const sh = ss.getSheetByName('Settings');
+  if (!sh) {
+    throw new Error('❌ لم يتم العثور على ورقة Settings. أنشئ ورقة باسم Settings وضع القيم في الصفوف المناسبة.');
+  }
 
-  // الصف2:
-  // A=AGENT_SHEET_ID, B=AGENT_SHEET_NAME, C=ADMIN_SHEET_ID, D=ADMIN_SHEET_NAME
-  // E=DATA1_ID, F=DATA1_NAME, G=DATA2_ID, H=DATA2_NAME  (اختياري)
-  const row = sh.getRange(2, 1, 1, 8).getValues()[0];
-  const cfg = {
-    AGENT_SHEET_ID:   String(row[0] || "").trim(),
-    AGENT_SHEET_NAME: String(row[1] || "").trim() || "SHEET",
-    ADMIN_SHEET_ID:   String(row[2] || "").trim(),
-    ADMIN_SHEET_NAME: String(row[3] || "").trim() || "Sheet1",
+  const lastRow = sh.getLastRow();
+  const lastCol = sh.getLastColumn();
+  if (lastRow < 2 || lastCol < 1) {
+    return { sections: [], map: {} };
+  }
 
-    DATA1_ID:         String(row[4] || "").trim(),
-    DATA1_NAME:       String(row[5] || "").trim() || "معلومات السلطان",
-    DATA2_ID:         String(row[6] || "").trim(),
-    DATA2_NAME:       String(row[7] || "").trim() || "معلومات الفرعيين",
-  };
-  const missing = [];
-  if (!cfg.AGENT_SHEET_ID)   missing.push("AGENT_SHEET_ID");
-  if (!cfg.AGENT_SHEET_NAME) missing.push("AGENT_SHEET_NAME");
-  if (!cfg.ADMIN_SHEET_ID)   missing.push("ADMIN_SHEET_ID");
-  if (!cfg.ADMIN_SHEET_NAME) missing.push("ADMIN_SHEET_NAME");
-  if (missing.length) throw new Error("⚠️ إعدادات ناقصة في Settings: " + missing.join(", "));
+  const rangeWidth = Math.min(lastCol, 20);
+  const rowsCount = lastRow - 1;
+  const values = rowsCount > 0 ? sh.getRange(2, 1, rowsCount, rangeWidth).getValues() : [];
+  const hasLabelColumn = lastCol >= 11;
+  const labelDisplayValues = (rowsCount > 0 && hasLabelColumn)
+    ? sh.getRange(2, 11, rowsCount, 1).getDisplayValues().map(r => (r && r.length ? r[0] : ''))
+    : [];
+
+  const sections = [];
+  const map = Object.create(null);
+  const rowMap = Object.create(null);
+  const tz = (function(){ try { return Session.getScriptTimeZone() || 'UTC'; } catch (_) { return 'UTC'; } })();
+
+  for (let i = 0; i < values.length; i++) {
+    const row = values[i] || [];
+    const rowIndex = i + 2;
+    const agentSheetId = String((row[0] || '')).trim();
+    const adminSheetId = String((row[2] || '')).trim();
+    const hasData = agentSheetId || adminSheetId || String((row[1] || '')).trim() || String((row[3] || '')).trim();
+    if (!hasData) {
+      // تجاهل الصفوف الفارغة بالكامل
+      continue;
+    }
+
+    const cfg = {
+      AGENT_SHEET_ID:   agentSheetId,
+      AGENT_SHEET_NAME: String((row[1] || '')).trim() || 'SHEET',
+      ADMIN_SHEET_ID:   adminSheetId,
+      ADMIN_SHEET_NAME: String((row[3] || '')).trim() || 'Sheet1',
+      DATA1_ID:         String((row[4] || '')).trim(),
+      DATA1_NAME:       String((row[5] || '')).trim() || 'معلومات السلطان',
+      DATA2_ID:         String((row[6] || '')).trim(),
+      DATA2_NAME:       String((row[7] || '')).trim() || 'معلومات الفرعيين',
+      EXTERNAL_ADMIN_URL: '',
+      EXTERNAL_ADMIN_SHEET: '',
+      EXTERNAL_AGENT_URL: '',
+      EXTERNAL_AGENT_SHEET: ''
+    };
+
+    const missing = [];
+    if (!cfg.AGENT_SHEET_ID)   missing.push('AGENT_SHEET_ID');
+    if (!cfg.AGENT_SHEET_NAME) missing.push('AGENT_SHEET_NAME');
+    if (!cfg.ADMIN_SHEET_ID)   missing.push('ADMIN_SHEET_ID');
+    if (!cfg.ADMIN_SHEET_NAME) missing.push('ADMIN_SHEET_NAME');
+    if (missing.length) {
+      throw new Error('⚠️ إعدادات ناقصة في Settings (الصف ' + rowIndex + '): ' + missing.join(', '));
+    }
+
+    // روابط الملفات الخارجية (الإدارة والوكيل)
+    const adminUrl = normalizeSheetLink_(row[8]);
+    if (adminUrl) {
+      cfg.EXTERNAL_ADMIN_URL = adminUrl;
+      cfg.EXTERNAL_ADMIN_SHEET = String((row[9] || '')).trim();
+    }
+
+    let agentUrlSlot = null;
+    for (let c = 10; c < row.length; c++) {
+      const norm = normalizeSheetLink_(row[c]);
+      if (norm) {
+        agentUrlSlot = { index: c, url: norm };
+        break;
+      }
+    }
+    if (agentUrlSlot) {
+      cfg.EXTERNAL_AGENT_URL = agentUrlSlot.url;
+      const sheetIdx = agentUrlSlot.index + 1;
+      if (sheetIdx < row.length) {
+        cfg.EXTERNAL_AGENT_SHEET = String((row[sheetIdx] || '')).trim();
+      }
+    }
+
+    let label = '';
+    const displayLabel = labelDisplayValues.length > i ? String(labelDisplayValues[i] || '').trim() : '';
+    const labelCell = row[10];
+    if (displayLabel) {
+      label = displayLabel;
+    } else if (labelCell instanceof Date) {
+      try {
+        label = Utilities.formatDate(labelCell, tz, 'dd/MM/yyyy');
+      } catch (_) {
+        label = String(labelCell);
+      }
+    } else {
+      label = String(labelCell || '').trim();
+    }
+    if (!label) {
+      for (let c = 10; c < row.length; c++) {
+        if (agentUrlSlot && (c === agentUrlSlot.index || c === agentUrlSlot.index + 1)) {
+          continue;
+        }
+        const raw = String((row[c] || '')).trim();
+        if (!raw) continue;
+        if (normalizeSheetLink_(raw)) continue;
+        label = raw;
+        break;
+      }
+    }
+    if (!label) {
+      label = 'قسم ' + (sections.length + 1);
+    }
+
+    const rowKey = String(rowIndex);
+    let key = label ? String(label) : rowKey;
+    if (!key) key = rowKey;
+    if (map[key]) key = rowKey;
+
+    const entry = {
+      key: key,
+      label: label,
+      rowIndex: rowIndex,
+      rowKey: rowKey,
+      config: cfg
+    };
+    sections.push(entry);
+    map[key] = entry;
+    rowMap[rowKey] = entry;
+  }
+
+  return { sections: sections, map: map, rowMap: rowMap };
+}
+
+function resolveActiveSectionKey_(preferredKey) {
+  const data = readSettingsSections_();
+  if (!data.sections.length) {
+    throw new Error('⚠️ لم يتم إعداد أي قسم في ورقة Settings.');
+  }
+
+  const userProps = PropertiesService.getUserProperties();
+  let key = String(preferredKey || '').trim();
+  if (key) {
+    if (!data.map[key] && data.rowMap && data.rowMap[key]) {
+      key = data.rowMap[key].key;
+    }
+    if (!data.map[key]) {
+      key = '';
+    }
+  }
+  if (!key && userProps) {
+    const stored = String(userProps.getProperty(PROP_ACTIVE_SECTION) || '').trim();
+    if (stored) {
+      let resolved = stored;
+      if (!data.map[resolved] && data.rowMap && data.rowMap[resolved]) {
+        resolved = data.rowMap[resolved].key;
+      }
+      if (data.map[resolved]) {
+        key = resolved;
+      }
+    }
+  }
+  if (!key || !data.map[key]) {
+    key = data.sections[0].key;
+  }
+  if (userProps) {
+    userProps.setProperty(PROP_ACTIVE_SECTION, key);
+  }
+  return { key: key, entry: data.map[key], listing: data.sections };
+}
+
+function getConfig_(options) {
+  const preferredKey = options && options.sectionKey;
+  const resolved = resolveActiveSectionKey_(preferredKey);
+  if (!resolved.entry) {
+    throw new Error('⚠️ لم يتم العثور على إعدادات القسم المحدد.');
+  }
+  const cfg = Object.assign({}, resolved.entry.config);
+  cfg.sectionKey = resolved.key;
+  cfg.sectionLabel = resolved.entry.label;
   return cfg;
 }
 
@@ -35,43 +192,70 @@ function getConfigStatus() {
   catch(e){ return { ok:false, message:e.message }; }
 }
 
+function getAvailableSections() {
+  try {
+    const data = readSettingsSections_();
+    if (!data.sections.length) {
+      throw new Error('⚠️ لم يتم العثور على أي أقسام في ورقة Settings.');
+    }
+    const cfg = getConfig_();
+    return {
+      ok: true,
+      sections: data.sections.map(s => ({ key: s.key, label: s.label })),
+      activeKey: cfg.sectionKey,
+      activeLabel: cfg.sectionLabel
+    };
+  } catch (e) {
+    return { ok:false, message:e.message };
+  }
+}
+
+function switchActiveSection(sectionKey) {
+  try {
+    const data = readSettingsSections_();
+    if (!data.sections.length) {
+      throw new Error('⚠️ لم يتم إعداد أي قسم في ورقة Settings.');
+    }
+    const key = String(sectionKey || '').trim();
+    let entry = data.map[key];
+    if (!entry && data.rowMap && data.rowMap[key]) {
+      entry = data.rowMap[key];
+    }
+    if (!entry) {
+      throw new Error('⚠️ القسم المحدد غير معروف.');
+    }
+    const userProps = PropertiesService.getUserProperties();
+    if (userProps) {
+      userProps.setProperty(PROP_ACTIVE_SECTION, entry.key);
+    }
+
+    const loadResult = loadDataIntoCache();
+    const snapshot = getSearchSnapshotLight();
+    return {
+      ok: true,
+      section: { key: entry.key, label: entry.label },
+      loadResult: loadResult,
+      snapshot: snapshot
+    };
+  } catch (e) {
+    return { ok:false, message:e.message };
+  }
+}
+
 function getExternalSheetLinksFromSettings() {
-  const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const sh = ss.getSheetByName('Settings');
-  if (!sh) throw new Error('❌ لم يتم العثور على ورقة Settings.');
-
-  const lastRow = sh.getLastRow();
-  if (lastRow < 1) throw new Error('⚠️ لا توجد بيانات في ورقة Settings للروابط الخارجية.');
-
-  const data = sh.getRange(1, 9, lastRow, 4).getDisplayValues(); // I:J:K:L
-
-  const admin = { url: '', sheetName: '' };
-  const agent = { url: '', sheetName: '' };
-
-  for (let i = 0; i < data.length; i++) {
-    const row = data[i];
-    if (!admin.url) {
-      const normalized = normalizeSheetLink_(row[0]);
-      if (normalized) {
-        admin.url = normalized;
-        admin.sheetName = String(row[1] || '').trim();
-      }
-    }
-    if (!agent.url) {
-      const normalized = normalizeSheetLink_(row[2]);
-      if (normalized) {
-        agent.url = normalized;
-        agent.sheetName = String(row[3] || '').trim();
-      }
-    }
-    if (admin.url && agent.url) break;
-  }
-
+  const cfg = getConfig_();
+  const admin = {
+    url: cfg.EXTERNAL_ADMIN_URL || '',
+    sheetName: cfg.EXTERNAL_ADMIN_SHEET || ''
+  };
+  const agent = {
+    url: cfg.EXTERNAL_AGENT_URL || '',
+    sheetName: cfg.EXTERNAL_AGENT_SHEET || ''
+  };
   if (!admin.url) {
-    throw new Error('⚠️ رابط ملف الإدارة الخارجي مفقود (تحقّق من العمود I في Settings).');
+    throw new Error('⚠️ رابط ملف الإدارة الخارجي مفقود في القسم الحالي (تحقّق من الأعمدة I-J).');
   }
-
-  return { admin, agent };
+  return { admin: admin, agent: agent };
 }
 
 /*****************************
@@ -542,6 +726,7 @@ function loadDataIntoCache() {
   try {
     const cache = CacheService.getScriptCache();
     const cfg = getConfig_();
+    const sectionLabel = cfg.sectionLabel || 'القسم الحالي';
 
     // الوكيل
     const agSS = SpreadsheetApp.openById(cfg.AGENT_SHEET_ID);
@@ -615,9 +800,16 @@ function loadDataIntoCache() {
       externalSummary = ' — ⚠️ فشل تحميل الخارجي: ' + (extErr && extErr.message ? extErr.message : String(extErr || ''));
     }
 
+    try {
+      const docProps = PropertiesService.getDocumentProperties();
+      if (docProps && cfg.sectionKey) {
+        docProps.setProperty(PROP_CACHE_SECTION, String(cfg.sectionKey));
+      }
+    } catch (_) {}
+
     return {
       success:true,
-      message:'تم التحميل ✓ — الوكيل: '+agentRows+' صف / '+agentUnique+' ID فريد — الإدارة: '+adminRows+' صف.' + externalSummary
+      message:'[' + sectionLabel + '] تم التحميل ✓ — الوكيل: '+agentRows+' صف / '+agentUnique+' ID فريد — الإدارة: '+adminRows+' صف.' + externalSummary
     };
   } catch (e) {
     return { success:false, message:'خطأ: ' + e.message };

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -449,6 +449,11 @@
       <button id="menuReload" class="drawer-item primary" type="button">تحميل البيانات</button>
       <button id="menuHome" class="drawer-item" type="button">الصفحة الرئيسية</button>
       <button id="menuBulk" class="drawer-item" type="button">أداة البحث الجماعي</button>
+      <div class="drawer-section">
+        <label class="small" for="menuSection">القسم الحالي</label>
+        <select id="menuSection"></select>
+        <div id="menuSectionStatus" class="drawer-note"></div>
+      </div>
       <div class="drawer-toggle">
         <span>الوضع الداكن</span>
         <button id="qtMode" type="button" aria-label="تبديل الوضع"></button>
@@ -569,6 +574,8 @@ const advCard  = document.getElementById('advCard');
     const menuReloadBtn   = document.getElementById('menuReload');
     const menuHomeBtn     = document.getElementById('menuHome');
     const menuBulkBtn     = document.getElementById('menuBulk');
+    const menuSectionSelect = document.getElementById('menuSection');
+    const menuSectionStatus = document.getElementById('menuSectionStatus');
     const viewTabs        = Array.from(document.querySelectorAll('.view-tab'));
     const mainViewEl      = document.getElementById('mainView');
     const bulkViewEl      = document.getElementById('bulkView');
@@ -604,6 +611,20 @@ const advCard  = document.getElementById('advCard');
     if (menuToggleBtn) menuToggleBtn.addEventListener('click', toggleDrawer);
     if (drawerCloseBtn) drawerCloseBtn.addEventListener('click', closeDrawer);
     if (drawerBackdrop) drawerBackdrop.addEventListener('click', closeDrawer);
+    if (menuSectionSelect) {
+      menuSectionSelect.addEventListener('change', () => {
+        const selected = menuSectionSelect.value;
+        if (!selected) return;
+        if (selected === activeSectionKey) {
+          if (activeSectionLabel) {
+            setSectionStatus('✅ القسم الحالي: ' + activeSectionLabel);
+          }
+          return;
+        }
+        performSectionSwitch(selected);
+      });
+    }
+    fetchSections();
 
     const viewsMap = { main: mainViewEl, bulk: bulkViewEl };
 
@@ -658,6 +679,10 @@ const advCard  = document.getElementById('advCard');
     let bulkPage = 1;
     let bulkMobileEnabled = false;
 
+    let sectionOptions = [];
+    let activeSectionKey = '';
+    let activeSectionLabel = '';
+
     const BULK_PAGE_SIZE = 20;
     const BULK_MOBILE_STORAGE_KEY = 'bulk_mobile_enabled';
     const JUST_COLORED_TTL = 120000;
@@ -695,6 +720,114 @@ const advCard  = document.getElementById('advCard');
       }
       if (menuDiscountInput && !options.skipInputUpdate) {
         menuDiscountInput.value = formatted;
+      }
+    }
+
+    function setSectionStatus(message){
+      if (menuSectionStatus) {
+        menuSectionStatus.textContent = message || '';
+      }
+    }
+
+    function rebuildSectionOptions(){
+      if (!menuSectionSelect) return;
+      const previous = menuSectionSelect.value;
+      menuSectionSelect.innerHTML = '';
+      sectionOptions.forEach(section => {
+        const opt = document.createElement('option');
+        opt.value = section.key || '';
+        opt.textContent = section.label || section.key || '';
+        menuSectionSelect.appendChild(opt);
+      });
+      const targetValue = activeSectionKey || previous;
+      if (targetValue) {
+        menuSectionSelect.value = targetValue;
+      }
+      if (!menuSectionSelect.value && menuSectionSelect.options.length) {
+        menuSectionSelect.selectedIndex = 0;
+      }
+      if (!activeSectionLabel && sectionOptions.length) {
+        const match = sectionOptions.find(s => s.key === menuSectionSelect.value);
+        activeSectionLabel = match ? match.label : '';
+      }
+      menuSectionSelect.disabled = sectionOptions.length <= 1;
+    }
+
+    async function fetchSections(options = {}){
+      if (!menuSectionSelect) return;
+      const keepStatus = options.keepStatus;
+      if (!keepStatus) setSectionStatus('⏳ جارٍ تحميل الأقسام…');
+      menuSectionSelect.disabled = true;
+      try {
+        const res = await runServer('getAvailableSections');
+        if (!res || res.ok === false) {
+          const msg = res?.message || 'فشل تحميل الأقسام.';
+          setSectionStatus('⚠️ ' + msg);
+          sectionOptions = [];
+          activeSectionKey = '';
+          activeSectionLabel = '';
+          menuSectionSelect.innerHTML = '';
+          menuSectionSelect.disabled = true;
+          return;
+        }
+        sectionOptions = Array.isArray(res.sections) ? res.sections : [];
+        activeSectionKey = res.activeKey || (sectionOptions[0]?.key || '');
+        const match = sectionOptions.find(s => s.key === activeSectionKey);
+        activeSectionLabel = res.activeLabel || (match ? match.label : '');
+        rebuildSectionOptions();
+        if (activeSectionLabel) {
+          setSectionStatus('✅ القسم الحالي: ' + activeSectionLabel);
+        } else {
+          setSectionStatus(sectionOptions.length ? 'اختر قسمًا لبدء العمل.' : 'لم يتم إعداد أي قسم.');
+        }
+      } catch (err) {
+        setSectionStatus('⚠️ حدث خطأ أثناء تحميل الأقسام: ' + (err?.message || err));
+        sectionOptions = [];
+        activeSectionKey = '';
+        activeSectionLabel = '';
+        menuSectionSelect.innerHTML = '';
+        menuSectionSelect.disabled = true;
+      }
+    }
+
+    async function performSectionSwitch(key){
+      const targetKey = String(key || '').trim();
+      if (!targetKey) return;
+      if (menuSectionSelect) menuSectionSelect.disabled = true;
+      setSectionStatus('⏳ جارٍ تحميل بيانات القسم…');
+      if (loadNote) loadNote.textContent = '⏳ جارٍ تحميل بيانات القسم…';
+      setLoadBtnState(false);
+      try {
+        const res = await runServer('switchActiveSection', targetKey);
+        if (!res || res.ok === false) {
+          const msg = res?.message || 'فشل تبديل القسم.';
+          setSectionStatus('⚠️ ' + msg);
+          if (loadNote) loadNote.textContent = '⚠️ ' + msg;
+          return;
+        }
+        activeSectionKey = res.section?.key || targetKey;
+        activeSectionLabel = res.section?.label || (sectionOptions.find(s => s.key === activeSectionKey)?.label || '');
+        rebuildSectionOptions();
+        const baseMsg = res.loadResult?.message || 'تم تحديث بيانات القسم.';
+        const serverOk = res.loadResult?.success !== false;
+        applyLoadResults(baseMsg, res.snapshot, { serverSuccess: serverOk });
+        if (activeSectionLabel) {
+          setSectionStatus('✅ القسم الحالي: ' + activeSectionLabel);
+        } else {
+          setSectionStatus('✅ تم تحديث القسم.');
+        }
+        if (typeof fillSheets === 'function') {
+          fillSheets();
+        } else {
+          refreshBulkSheets();
+        }
+      } catch (err) {
+        setSectionStatus('⚠️ حدث خطأ أثناء تحديث القسم: ' + (err?.message || err));
+      } finally {
+        if (menuSectionSelect) {
+          menuSectionSelect.disabled = sectionOptions.length <= 1;
+          menuSectionSelect.value = activeSectionKey || '';
+        }
       }
     }
 
@@ -1354,7 +1487,9 @@ const advCard  = document.getElementById('advCard');
         const salaryVal = Number(baseSalaryRaw || 0);
         const salaryStr = salaryVal.toFixed(2);
         if (mode === 'salary') return salaryStr;
-        return [res.id || '', salaryStr, res.state || ''].join('\t');
+        const stateText = res.state || '';
+        const duplicateText = res.duplicateLabel ? `${stateText ? ' - ' : ''}${res.duplicateLabel}` : '';
+        return [res.id || '', salaryStr, `${stateText}${duplicateText}`.trim()].join('\t');
       });
       const text = rows.join('\n');
       const successMessage = copyingDuringRun
@@ -1498,6 +1633,26 @@ const advCard  = document.getElementById('advCard');
       if (ok===true){ reloadBtn.classList.remove('btn-red'); reloadBtn.classList.add('btn-green'); }
       else if (ok===false){ reloadBtn.classList.remove('btn-green'); reloadBtn.classList.add('btn-red'); }
     }
+
+    function applyLoadResults(baseMessage, snapshot, options = {}){
+      if (!loadNote) return;
+      const baseMsg = baseMessage || 'تم التحميل من السيرفر.';
+      const serverOk = options.serverSuccess !== false;
+      if (!snapshot || snapshot.ok === false) {
+        const extra = snapshot && snapshot.message ? snapshot.message : '';
+        loadNote.textContent = extra
+          ? `${baseMsg} | ⚠️ فشل المحلي: ${extra}`
+          : `${baseMsg} | ⚠️ فشل التحميل المحلي.`;
+        setLoadBtnState(false);
+        return;
+      }
+      localMap = snapshot.map || null;
+      rebuildSortedLocalIds();
+      const st = snapshot.stats || {};
+      loadNote.textContent = `${baseMsg} | محلي: ${st.agentRows||0} صف / ${st.agentUnique||0} ID.`;
+      setLoadBtnState(serverOk);
+      refreshCountsLive();
+    }
     function loadData(){
       setLoadBtnState(false);
       loadNote.textContent = '⏳ جارٍ تحميل البيانات…';
@@ -1506,17 +1661,8 @@ const advCard  = document.getElementById('advCard');
           const baseMsg = srv?.message || 'تم التحميل من السيرفر.';
           google.script.run
             .withSuccessHandler(res=>{
-              if(!res || !res.ok){
-                loadNote.textContent = baseMsg + ' | ⚠️ فشل المحلي: ' + (res?.message||'');
-                setLoadBtnState(false);
-                return;
-              }
-              localMap = res.map || null;
-              rebuildSortedLocalIds();
-              const st = res.stats || {};
-              loadNote.textContent = `${baseMsg} | محلي: ${st.agentRows||0} صف / ${st.agentUnique||0} ID.`;
-              setLoadBtnState(true);
-              refreshCountsLive();
+              const serverOk = srv?.success !== false;
+              applyLoadResults(baseMsg, res, { serverSuccess: serverOk });
             })
             .withFailureHandler(err=>{
               loadNote.textContent = baseMsg + ' | ⚠️ خطأ بالمحلي: ' + (err?.message||'');


### PR DESCRIPTION
## Summary
- read Settings rows with awareness of the column K display value, formatting dates and falling back to other cells to name each section uniquely
- keep a row index map so section lookups accept both the new labels and legacy numeric keys when resolving, persisting, or switching sections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3591eebe08324bc7e98e90abc7b63