### PR TITLE
Refine section UI and add AI ID suggestions

### DIFF
--- a/AI.gs
+++ b/AI.gs
@@ -1,0 +1,202 @@
+function aiSuggestIds(query, limit) {
+  try {
+    const rawQuery = String(query || '').trim();
+    const limitNum = Math.max(1, Math.min(30, Number(limit) || 12));
+    if (!rawQuery) {
+      return { ok: true, items: [], meta: { total: 0 } };
+    }
+
+    const cfg = getConfig_();
+    const sectionKey = getEffectiveSectionKey_(cfg) || 'default';
+    const cache = CacheService.getScriptCache();
+
+    const agentIndex = cacheGetChunked_(qualifySectionCacheKey_(KEY_AGENT_INDEX, sectionKey), cache) || {};
+    const adminIdSet = cacheGetChunked_(qualifySectionCacheKey_(KEY_ADMIN_IDSET, sectionKey), cache) || {};
+    const coloredAgent = cacheGetChunked_(qualifySectionCacheKey_(KEY_COLORED_AGENT, sectionKey), cache) || {};
+    const coloredAdmin = cacheGetChunked_(qualifySectionCacheKey_(KEY_COLORED_ADMIN, sectionKey), cache) || {};
+    const infoGroups = cacheGetChunked_(qualifySectionCacheKey_(KEY_INFO_GROUPS, sectionKey), cache) || {};
+    const infoId2Group = cacheGetChunked_(qualifySectionCacheKey_(KEY_INFO_ID2GROUP, sectionKey), cache) || {};
+
+    const agentKeys = Object.keys(agentIndex);
+    const adminKeys = Object.keys(adminIdSet);
+    if (!agentKeys.length && !adminKeys.length) {
+      return { ok: false, message: 'البيانات غير محمّلة. اضغط «تحميل البيانات» ثم أعد المحاولة.' };
+    }
+
+    const numericQuery = /^\d+$/.test(rawQuery);
+    const loweredQuery = rawQuery.toLowerCase();
+    const suggestions = new Map();
+
+    function addCandidate(id, node, meta) {
+      const key = String(id || '').trim();
+      if (!key) return;
+      const matchKind = meta && meta.matchKind ? meta.matchKind : (numericQuery ? 'id' : 'name');
+      const score = Number(meta && meta.score);
+      const matchValue = String(meta && meta.matchValue ? meta.matchValue : '');
+      const existing = suggestions.get(key);
+      if (existing) {
+        if (isFinite(score) && score < existing.score) {
+          existing.score = score;
+          existing.matchKind = matchKind;
+          existing.matchValue = matchValue;
+        }
+        if (!existing.node && node) existing.node = node;
+        return;
+      }
+      suggestions.set(key, {
+        id: key,
+        node: node || null,
+        score: isFinite(score) ? score : 9999,
+        matchKind: matchKind,
+        matchValue: matchValue,
+        adminOnly: !!(meta && meta.adminOnly)
+      });
+    }
+
+    // ابحث داخل فهرس الوكيل (حسب الـID أو الاسم)
+    for (let i = 0; i < agentKeys.length; i++) {
+      const id = agentKeys[i];
+      const node = agentIndex[id] || {};
+      if (numericQuery) {
+        const idx = id.indexOf(rawQuery);
+        if (idx === -1) continue;
+        const score = (idx === 0 ? 0 : 2) + Math.abs(id.length - rawQuery.length) * 0.01 + i * 0.0001;
+        addCandidate(id, node, { score, matchKind: 'id', matchValue: id });
+        continue;
+      }
+
+      const names = Array.isArray(node.names) ? node.names : [];
+      let bestScore = Infinity;
+      let bestName = '';
+      for (let j = 0; j < names.length; j++) {
+        const name = String(names[j] || '');
+        if (!name) continue;
+        const lower = name.toLowerCase();
+        const idx = lower.indexOf(loweredQuery);
+        if (idx === -1) continue;
+        const candidateScore = (idx === 0 ? 0 : 1.5) + lower.length * 0.002 + j * 0.05 + i * 0.0001;
+        if (candidateScore < bestScore) {
+          bestScore = candidateScore;
+          bestName = name;
+        }
+      }
+      if (bestName) {
+        addCandidate(id, node, { score: bestScore, matchKind: 'name', matchValue: bestName });
+      }
+    }
+
+    if (numericQuery) {
+      for (let i = 0; i < adminKeys.length; i++) {
+        const id = adminKeys[i];
+        const idx = id.indexOf(rawQuery);
+        if (idx === -1) continue;
+        const score = (idx === 0 ? 1 : 3) + Math.abs(id.length - rawQuery.length) * 0.02 + i * 0.0001;
+        addCandidate(id, agentIndex[id] || null, { score, matchKind: 'id', matchValue: id, adminOnly: !agentIndex[id] });
+      }
+    } else {
+      const groupKeys = Object.keys(infoGroups || {});
+      for (let i = 0; i < groupKeys.length; i++) {
+        const group = infoGroups[groupKeys[i]];
+        if (!group) continue;
+        const name = String(group.name || '').trim();
+        if (!name) continue;
+        const lower = name.toLowerCase();
+        const idx = lower.indexOf(loweredQuery);
+        if (idx === -1) continue;
+        const baseScore = (idx === 0 ? 0.6 : 1.8) + lower.length * 0.001 + i * 0.0001;
+        const ids = Array.isArray(group.ids) ? group.ids : [];
+        for (let j = 0; j < ids.length; j++) {
+          const id = String((ids[j] && ids[j].id) || '').trim();
+          if (!id) continue;
+          addCandidate(id, agentIndex[id] || null, { score: baseScore + j * 0.05, matchKind: 'name', matchValue: name });
+        }
+      }
+    }
+
+    if (!suggestions.size) {
+      return { ok: true, items: [], meta: { total: 0 } };
+    }
+
+    const items = [];
+    suggestions.forEach((entry, id) => {
+      const node = entry.node || agentIndex[id] || null;
+      const inAgent = !!node;
+      const inAdmin = !!adminIdSet[id];
+
+      let status = 'غير موجود';
+      let total = 0;
+      let rowsCount = 0;
+      let primaryName = '';
+
+      if (inAgent) {
+        const rows = Array.isArray(node.rows) ? node.rows : [];
+        rowsCount = rows.length;
+        total = Number(node.sum || 0);
+        const names = Array.isArray(node.names) ? node.names : [];
+        if (names.length) {
+          primaryName = String(names[0] || '').trim();
+        }
+        if (rowsCount > 0) {
+          status = inAdmin
+            ? (rowsCount > 1 ? 'سحب وكالة - راتبين' : 'سحب وكالة')
+            : (rowsCount > 1 ? 'راتبين' : 'وكالة');
+        } else if (inAdmin) {
+          status = 'ادارة';
+        }
+      } else if (inAdmin) {
+        status = 'ادارة';
+      }
+
+      if (!primaryName && entry.matchKind === 'name' && entry.matchValue) {
+        primaryName = String(entry.matchValue).trim();
+      }
+      if (!primaryName && infoId2Group && infoId2Group[id]) {
+        const gk = infoId2Group[id];
+        if (gk && infoGroups && infoGroups[gk] && infoGroups[gk].name) {
+          primaryName = String(infoGroups[gk].name || '').trim();
+        }
+      }
+
+      const isColoredAgent = !!coloredAgent[id];
+      const isColoredAdmin = !!coloredAdmin[id];
+      const colored = isColoredAgent || isColoredAdmin;
+
+      let duplicateLabel = '';
+      if (isColoredAgent && isColoredAdmin) duplicateLabel = 'مكرر';
+      else if (isColoredAgent) duplicateLabel = 'مكرر وكالة فقط';
+      else if (isColoredAdmin) duplicateLabel = 'مكرر ادارة فقط';
+
+      const totalFixed = Number.isFinite(total) ? Number(total.toFixed(2)) : 0;
+
+      items.push({
+        id: id,
+        status: status,
+        totalSalary: totalFixed,
+        colored: colored,
+        duplicateLabel: duplicateLabel,
+        rowsCount: rowsCount,
+        matchKind: entry.matchKind,
+        matchValue: entry.matchValue || '',
+        primaryName: primaryName,
+        inAgent: inAgent,
+        inAdmin: inAdmin,
+        score: entry.score
+      });
+    });
+
+    items.sort((a, b) => {
+      if (a.score !== b.score) return a.score - b.score;
+      if (a.matchKind !== b.matchKind) {
+        if (a.matchKind === 'id') return -1;
+        if (b.matchKind === 'id') return 1;
+      }
+      if (a.rowsCount !== b.rowsCount) return b.rowsCount - a.rowsCount;
+      return a.id.localeCompare(b.id, 'ar');
+    });
+
+    const limited = items.slice(0, limitNum);
+    return { ok: true, items: limited, meta: { total: items.length } };
+  } catch (err) {
+    return { ok: false, message: err && err.message ? err.message : String(err || '') };
+  }
+}

--- a/AIClient.html
+++ b/AIClient.html
@@ -1,0 +1,272 @@
+<script>
+(function(){
+  const mount = document.getElementById('aiMountHere');
+  if (!mount) return;
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .ai-suggest-card{margin-top:18px;background:var(--surface);border-radius:22px;padding:18px;border:1px solid rgba(255,255,255,.06);display:flex;flex-direction:column;gap:14px;box-shadow:0 20px 54px rgba(8,14,26,.38);}
+    .ai-suggest-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;flex-wrap:wrap;}
+    .ai-suggest-headings{display:flex;flex-direction:column;gap:4px;}
+    .ai-suggest-title{font-size:16px;font-weight:800;color:var(--accent);}
+    .ai-suggest-sub{font-size:12px;color:var(--muted);max-width:320px;}
+    .ai-suggest-chip{padding:6px 12px;border-radius:999px;border:1px solid rgba(43,255,168,.26);background:rgba(43,255,168,.08);color:var(--accent);font-size:12px;font-weight:700;white-space:nowrap;transition:background .18s ease,border .18s ease,color .18s ease;}
+    .ai-suggest-chip.is-empty{background:rgba(255,255,255,.05);border-color:rgba(255,255,255,.08);color:var(--muted);}
+    .ai-suggest-search{display:flex;align-items:center;gap:8px;}
+    .ai-suggest-search input{flex:1;padding:12px 14px;border-radius:16px;border:1px solid rgba(255,255,255,.08);background:var(--surface-strong);color:var(--text);outline:none;transition:border .18s ease,box-shadow .18s ease;}
+    .ai-suggest-search input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-dim);}
+    .ai-suggest-search button{flex:0 0 auto;width:38px;height:38px;border-radius:12px;background:var(--surface-strong);border:1px solid rgba(255,255,255,.08);color:var(--muted);cursor:pointer;transition:background .18s ease,color .18s ease,border .18s ease;}
+    .ai-suggest-search button:hover{color:var(--accent);border-color:rgba(43,255,168,.28);}
+    .ai-suggest-search button:disabled{opacity:.4;cursor:not-allowed;color:var(--muted);}
+    .ai-suggest-status{font-size:12px;color:var(--muted);min-height:16px;}
+    .ai-suggest-results{display:flex;flex-direction:column;gap:10px;max-height:320px;overflow:auto;padding-inline-end:6px;}
+    .ai-suggest-results::-webkit-scrollbar{width:6px;}
+    .ai-suggest-results::-webkit-scrollbar-thumb{background:rgba(255,255,255,.12);border-radius:999px;}
+    .ai-suggest-empty{padding:18px;border-radius:16px;text-align:center;color:var(--muted);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.06);}
+    .ai-suggest-item{border:none;background:var(--surface-strong);border-radius:18px;padding:14px;display:flex;flex-direction:column;gap:10px;align-items:stretch;text-align:right;cursor:pointer;border:1px solid rgba(255,255,255,.06);box-shadow:0 16px 40px rgba(8,14,26,.34);transition:transform .18s ease,box-shadow .18s ease,border .18s ease;}
+    .ai-suggest-item:hover{transform:translateY(-2px);border-color:rgba(43,255,168,.28);box-shadow:0 20px 48px rgba(12,22,36,.42);}
+    .ai-suggest-top{display:flex;align-items:center;gap:10px;justify-content:space-between;}
+    .ai-suggest-id{font-size:17px;font-weight:800;font-variant-numeric:tabular-nums;color:var(--text-strong);}
+    .ai-suggest-id mark{background:rgba(43,255,168,.26);color:var(--text-strong);border-radius:4px;padding:0 2px;}
+    .ai-suggest-status{padding:4px 10px;border-radius:999px;font-size:11px;font-weight:700;border:1px solid transparent;}
+    .ai-suggest-status--agent{background:rgba(56,189,248,.14);border-color:rgba(56,189,248,.32);color:#8cdcff;}
+    .ai-suggest-status--withdraw{background:rgba(77,228,161,.16);border-color:rgba(77,228,161,.32);color:#4de4a1;}
+    .ai-suggest-status--admin{background:rgba(250,204,21,.16);border-color:rgba(250,204,21,.36);color:#facc15;}
+    .ai-suggest-status--missing{background:rgba(255,255,255,.08);border-color:rgba(255,255,255,.14);color:var(--muted);}
+    .ai-suggest-status--other{background:rgba(255,255,255,.08);border-color:rgba(255,255,255,.14);color:var(--muted);}
+    .ai-suggest-body{display:flex;flex-direction:column;gap:6px;}
+    .ai-suggest-name{font-size:13px;color:var(--text);word-break:break-word;}
+    .ai-suggest-name mark{background:rgba(43,255,168,.26);color:var(--text-strong);border-radius:4px;padding:0 2px;}
+    .ai-suggest-foot{display:flex;flex-wrap:wrap;gap:6px;align-items:center;font-size:11px;color:var(--muted);}
+    .ai-suggest-sum{color:var(--text-strong);font-weight:600;}
+    .ai-suggest-chip{display:inline-flex;align-items:center;gap:4px;padding:4px 8px;border-radius:999px;background:rgba(255,255,255,.05);border:1px solid rgba(255,255,255,.08);font-size:11px;font-weight:600;color:var(--muted);}
+    .ai-suggest-chip--dup{background:rgba(255,93,117,.16);border-color:rgba(255,93,117,.28);color:#ff8da4;}
+    .ai-suggest-chip--colored{background:rgba(43,255,168,.16);border-color:rgba(43,255,168,.32);color:#2bffa8;}
+    .ai-suggest-chip--plain{background:rgba(255,255,255,.06);border-color:rgba(255,255,255,.12);color:var(--muted);}
+    .ai-suggest-chip--hint{background:rgba(56,189,248,.14);border-color:rgba(56,189,248,.28);color:#8cdcff;}
+    .ai-suggest-hint{font-size:11px;color:var(--muted);}
+    .ai-suggest-hint mark{background:rgba(43,255,168,.18);color:var(--text-strong);border-radius:4px;padding:0 2px;}
+    @media(min-width:1024px){
+      .ai-suggest-card{margin-top:22px;}
+    }
+  `;
+  document.head.appendChild(style);
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'ai-suggest-card';
+  wrapper.innerHTML = `
+    <div class="ai-suggest-head">
+      <div class="ai-suggest-headings">
+        <div class="ai-suggest-title">مقترحات الـIDs</div>
+        <div class="ai-suggest-sub">اعثر على سجلات مشابهة بسرعة حسب القسم الحالي.</div>
+      </div>
+      <div class="ai-suggest-chip is-empty" data-ai-section>—</div>
+    </div>
+    <div class="ai-suggest-search">
+      <input type="text" data-ai-query placeholder="اكتب جزءًا من الاسم أو الـID" autocomplete="off" inputmode="search" />
+      <button type="button" data-ai-clear aria-label="مسح">✕</button>
+    </div>
+    <div class="ai-suggest-status" data-ai-status></div>
+    <div class="ai-suggest-results" data-ai-results></div>
+  `;
+  mount.appendChild(wrapper);
+
+  const queryInput = wrapper.querySelector('[data-ai-query]');
+  const clearBtn = wrapper.querySelector('[data-ai-clear]');
+  const resultsEl = wrapper.querySelector('[data-ai-results]');
+  const statusEl = wrapper.querySelector('[data-ai-status]');
+  const sectionChip = wrapper.querySelector('[data-ai-section]');
+
+  let debounceHandle = null;
+  let lastQuery = '';
+  let lastRequestId = 0;
+
+  const numberFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
+
+  const escapeHtml = (txt) => String(txt || '').replace(/[&<>"']/g, ch => {
+    switch (ch) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '"': return '&quot;';
+      case "'": return '&#39;';
+      default: return ch;
+    }
+  });
+  function escapeRegExp(txt){
+    return String(txt || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function highlight(text, query){
+    const safe = escapeHtml(text);
+    if (!query) return safe;
+    try {
+      const regex = new RegExp(escapeRegExp(query), 'ig');
+      return safe.replace(regex, match => `<mark>${match}</mark>`);
+    } catch (_) {
+      return safe;
+    }
+  }
+
+  function renderEmpty(message){
+    resultsEl.innerHTML = `<div class="ai-suggest-empty">${escapeHtml(message)}</div>`;
+  }
+
+  function setStatus(message){
+    statusEl.textContent = message || '';
+  }
+
+  function statusClassFromText(text){
+    const t = String(text || '').trim();
+    if (!t) return 'other';
+    if (t.includes('سحب وكالة')) return 'withdraw';
+    if (t.includes('وكال')) return 'agent';
+    if (t.includes('ادارة')) return 'admin';
+    if (t.includes('غير موجود')) return 'missing';
+    return 'other';
+  }
+
+  function syncClearButton(){
+    if (!clearBtn) return;
+    const has = !!String(queryInput.value || '').trim();
+    clearBtn.disabled = !has;
+  }
+
+  function renderItems(items){
+    if (!items.length){
+      renderEmpty('لا توجد مقترحات مطابقة.');
+      return;
+    }
+    const frag = document.createDocumentFragment();
+    items.forEach(item => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ai-suggest-item';
+      const statusClass = statusClassFromText(item.status || '');
+      const idHtml = item.matchKind === 'id' ? highlight(item.id || '', lastQuery) : escapeHtml(item.id || '');
+      const nameQuery = item.matchKind === 'name' ? lastQuery : '';
+      const displayName = item.primaryName ? highlight(item.primaryName, nameQuery) : '—';
+      const matchLabel = item.matchKind === 'name' && item.matchValue && item.matchValue !== item.primaryName
+        ? `<div class="ai-suggest-hint">${highlight(item.matchValue, lastQuery)}</div>`
+        : '';
+      const totalLabel = numberFormatter.format(Number(item.totalSalary || 0));
+      const chips = [];
+      chips.push(`<span class="ai-suggest-chip ${item.colored ? 'ai-suggest-chip--colored' : 'ai-suggest-chip--plain'}">${item.colored ? 'ملوّن' : 'غير ملوّن'}</span>`);
+      if (item.rowsCount > 1) chips.push('<span class="ai-suggest-chip">راتبين</span>');
+      if (item.duplicateLabel) chips.push(`<span class="ai-suggest-chip ai-suggest-chip--dup">${escapeHtml(item.duplicateLabel)}</span>`);
+      chips.push('<span class="ai-suggest-chip ai-suggest-chip--hint">' + (item.matchKind === 'name' ? 'مطابقة بالاسم' : 'مطابقة بالرقم') + '</span>');
+
+      btn.innerHTML = `
+        <div class="ai-suggest-top">
+          <span class="ai-suggest-id">${idHtml}</span>
+          <span class="ai-suggest-status ai-suggest-status--${statusClass}">${escapeHtml(item.status || '—')}</span>
+        </div>
+        <div class="ai-suggest-body">
+          <div class="ai-suggest-name">${displayName}</div>
+          <div class="ai-suggest-foot">
+            <span class="ai-suggest-sum">المجموع: ${totalLabel}</span>
+            ${chips.join('')}
+          </div>
+          ${matchLabel}
+        </div>
+      `;
+      btn.addEventListener('click', () => {
+        const input = document.getElementById('idInput');
+        if (input) {
+          input.value = item.id || '';
+          input.focus();
+        }
+        if (typeof doSearch === 'function') {
+          setTimeout(() => doSearch({ allowSuggestions: true }), 0);
+        }
+      });
+      frag.appendChild(btn);
+    });
+    resultsEl.innerHTML = '';
+    resultsEl.appendChild(frag);
+  }
+
+  function fetchSuggestions(query){
+    const trimmed = String(query || '').trim();
+    lastQuery = trimmed;
+    syncClearButton();
+    if (!trimmed){
+      setStatus('');
+      renderEmpty('ابدأ بالكتابة لعرض المقترحات.');
+      return;
+    }
+    if (trimmed.length < 2){
+      setStatus('');
+      renderEmpty('اكتب حرفين على الأقل للحصول على نتائج.');
+      return;
+    }
+    const requestId = ++lastRequestId;
+    setStatus('⏳ جارٍ التحليل…');
+    google.script.run
+      .withSuccessHandler(res => {
+        if (requestId !== lastRequestId) return;
+        const items = Array.isArray(res && res.items) ? res.items : [];
+        if (!res || res.ok === false){
+          setStatus('');
+          renderEmpty('⚠️ ' + escapeHtml(res && res.message ? res.message : 'تعذر جلب المقترحات.'));
+          return;
+        }
+        renderItems(items);
+        if (res.meta && typeof res.meta.total === 'number' && res.meta.total > items.length) {
+          setStatus(`عرض أول ${items.length} من ${res.meta.total} نتيجة.`);
+        } else {
+          setStatus(items.length ? `تم العثور على ${items.length} مقترح.` : '');
+        }
+      })
+      .withFailureHandler(err => {
+        if (requestId !== lastRequestId) return;
+        setStatus('');
+        renderEmpty('⚠️ ' + escapeHtml(err && err.message ? err.message : err));
+      })
+      .aiSuggestIds(trimmed, 18);
+  }
+
+  function scheduleFetch(){
+    clearTimeout(debounceHandle);
+    debounceHandle = setTimeout(() => fetchSuggestions(queryInput.value), 220);
+  }
+
+  queryInput.addEventListener('input', scheduleFetch);
+  queryInput.addEventListener('keydown', evt => {
+    if (evt.key === 'Enter') {
+      evt.preventDefault();
+      clearTimeout(debounceHandle);
+      fetchSuggestions(queryInput.value);
+    }
+  });
+
+  clearBtn.addEventListener('click', () => {
+    queryInput.value = '';
+    syncClearButton();
+    queryInput.focus();
+    lastQuery = '';
+    renderEmpty('ابدأ بالكتابة لعرض المقترحات.');
+    setStatus('');
+  });
+
+  renderEmpty('ابدأ بالكتابة لعرض المقترحات.');
+  syncClearButton();
+
+  function applySectionLabel(label){
+    const safe = String(label || '').trim();
+    if (sectionChip) {
+      sectionChip.textContent = safe || '—';
+      sectionChip.classList.toggle('is-empty', !safe);
+    }
+    if (safe && queryInput.value && queryInput.value.trim()) {
+      clearTimeout(debounceHandle);
+      debounceHandle = setTimeout(() => fetchSuggestions(queryInput.value), 80);
+    }
+  }
+
+  window.__aiClient = window.__aiClient || {};
+  window.__aiClient.setActiveSection = applySectionLabel;
+
+  applySectionLabel(window.__activeSectionLabel || '');
+})();
+</script>

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -44,10 +44,16 @@
     @media(min-width:520px){.app-shell{max-width:520px;}}
     .app-header{display:flex;align-items:center;gap:14px;}
     .hamburger{width:46px;height:46px;display:inline-flex;align-items:center;justify-content:center;border-radius:16px;background:var(--surface-strong);border:1px solid var(--border);color:var(--accent);box-shadow:0 10px 26px rgba(18,233,153,.18);}
-    .header-meta{display:flex;flex-direction:row;align-items:stretch;gap:12px;margin-inline-start:auto;flex-wrap:wrap;justify-content:flex-end;}
-    .counter-pill{display:flex;flex-direction:column;align-items:center;justify-content:center;background:var(--surface-strong);padding:10px 14px;border-radius:16px;min-width:98px;box-shadow:0 10px 28px rgba(23,30,44,.36);border:1px solid var(--border);}
-    .counter-pill .label{font-size:11px;color:var(--muted);letter-spacing:.4px;}
-    .counter-pill .value{font-size:18px;font-weight:800;color:var(--accent);}
+    .header-meta{margin-inline-start:auto;display:flex;flex-wrap:wrap;align-items:center;justify-content:flex-end;}
+    .counter-cluster{display:flex;align-items:center;justify-content:center;gap:12px;background:var(--surface-strong);padding:10px 14px;border-radius:18px;border:1px solid var(--border);box-shadow:0 12px 30px rgba(16,26,44,.36);flex-wrap:wrap;}
+    .counter-mini{display:flex;flex-direction:column;align-items:center;justify-content:center;min-width:86px;padding:4px 0;flex:1 1 80px;}
+    .counter-mini .label{font-size:11px;color:var(--muted);letter-spacing:.4px;}
+    .counter-mini .value{font-size:16px;font-weight:800;color:var(--accent);}
+    .section-chip{display:flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;border:1px solid rgba(43,255,168,.26);background:rgba(43,255,168,.08);color:var(--accent);font-weight:700;white-space:nowrap;flex:0 0 auto;transition:background .18s ease,border .18s ease,color .18s ease;}
+    .section-chip .chip-label{font-size:11px;letter-spacing:.3px;color:var(--muted);}
+    .section-chip .chip-value{color:var(--text-strong);font-size:13px;}
+    .section-chip.is-empty{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.08);color:var(--muted);}
+    .section-chip.is-empty .chip-value{color:var(--muted);}
     .view-switch{display:flex;gap:10px;}
     .view-tab{flex:1;background:var(--surface);border:1px solid transparent;border-radius:16px;padding:12px 14px;color:var(--muted);font-weight:700;}
     .view-tab.active{background:linear-gradient(135deg,var(--surface-strong),#1c2537);color:var(--accent);border-color:rgba(43,255,168,.22);box-shadow:0 12px 32px rgba(26,214,145,.22);}
@@ -81,16 +87,16 @@
     #searchCard{background:var(--surface);border-radius:22px;box-shadow:none;border:1px solid rgba(255,255,255,.05);}
     #searchCard button{min-width:160px;}
     #searchCard .column button{width:100%;}
-    #nearbyBox{display:none;margin-top:12px;padding:14px 16px;border-radius:18px;background:rgba(15,23,34,0.9);border:1px solid rgba(43,255,168,.28);box-shadow:0 18px 42px rgba(14,146,112,.28);backdrop-filter:blur(18px);transition:transform .18s ease,opacity .18s ease;}
+    #nearbyBox{display:none;margin-top:12px;padding:16px;border-radius:18px;background:var(--surface-strong);border:1px solid var(--border);box-shadow:0 18px 42px rgba(8,14,26,.32);transition:transform .18s ease,opacity .18s ease;}
     #nearbyBox.show{display:block;opacity:1;transform:translateY(0);}
-    #nearbyBox:not(.show){opacity:0;transform:translateY(4px);}
+    #nearbyBox:not(.show){opacity:0;transform:translateY(6px);}
     .nearby-header{font-size:12px;font-weight:800;color:var(--muted);letter-spacing:.4px;margin-bottom:10px;}
-    .nearby-list{display:flex;flex-direction:column;gap:8px;}
-    .nearby-item{border:none;display:flex;align-items:center;justify-content:space-between;gap:14px;padding:11px 14px;border-radius:14px;background:rgba(43,255,168,.1);color:var(--text);font-weight:700;text-align:right;cursor:pointer;transition:background .18s ease,border .18s ease,transform .18s ease;box-shadow:0 12px 28px rgba(12,70,54,.25);border:1px solid rgba(43,255,168,.18);}
-    .nearby-item:hover{background:rgba(43,255,168,.18);border-color:rgba(43,255,168,.35);}
+    .nearby-list{display:flex;flex-direction:column;gap:10px;}
+    .nearby-item{border:none;display:flex;align-items:center;justify-content:space-between;gap:14px;padding:12px 14px;border-radius:14px;background:var(--surface);color:var(--text);font-weight:700;text-align:right;cursor:pointer;transition:background .18s ease,border .18s ease,transform .18s ease,box-shadow .18s ease;border:1px solid rgba(255,255,255,.06);box-shadow:0 12px 26px rgba(7,12,22,.28);}
+    .nearby-item:hover{background:rgba(43,255,168,.12);border-color:rgba(43,255,168,.24);}
     .nearby-item:active{transform:scale(.985);}
-    .nearby-item--primary{background:linear-gradient(135deg,rgba(43,255,168,.24),rgba(56,189,248,.24));border-color:rgba(56,189,248,.42);box-shadow:0 14px 34px rgba(43,255,168,.28);}
-    .nearby-item--primary:hover{background:linear-gradient(135deg,rgba(43,255,168,.32),rgba(56,189,248,.32));}
+    .nearby-item--primary{background:linear-gradient(135deg,rgba(43,255,168,.18),rgba(56,189,248,.18));border-color:rgba(56,189,248,.34);box-shadow:0 14px 32px rgba(26,94,81,.35);}
+    .nearby-item--primary:hover{background:linear-gradient(135deg,rgba(43,255,168,.24),rgba(56,189,248,.24));}
     .nearby-id{font-size:16px;font-variant-numeric:tabular-nums;color:var(--text-strong);}
     .nearby-status{font-size:13px;color:var(--muted);margin-inline-start:auto;}
     .nearby-diff{font-size:11px;color:rgba(226,232,240,.75);min-width:42px;text-align:left;direction:ltr;}
@@ -196,13 +202,19 @@
     <header class="app-header">
       <button id="menuToggle" class="hamburger" type="button" aria-label="القائمة">☰</button>
       <div class="header-meta">
-        <div class="counter-pill">
-          <span class="label">ملوّن</span>
-          <span id="qtColored" class="value">—</span>
-        </div>
-        <div class="counter-pill">
-          <span class="label">غير ملوّن</span>
-          <span id="qtUncolored" class="value">—</span>
+        <div class="counter-cluster">
+          <div class="counter-mini">
+            <span class="label">ملوّن</span>
+            <span id="qtColored" class="value">—</span>
+          </div>
+          <div class="counter-mini">
+            <span class="label">غير ملوّن</span>
+            <span id="qtUncolored" class="value">—</span>
+          </div>
+          <div id="sectionChip" class="section-chip" title="القسم الحالي">
+            <span class="chip-label">القسم</span>
+            <span id="headerSectionLabel" class="chip-value">—</span>
+          </div>
         </div>
       </div>
     </header>
@@ -449,6 +461,11 @@
       <button id="menuReload" class="drawer-item primary" type="button">تحميل البيانات</button>
       <button id="menuHome" class="drawer-item" type="button">الصفحة الرئيسية</button>
       <button id="menuBulk" class="drawer-item" type="button">أداة البحث الجماعي</button>
+      <div class="drawer-section">
+        <label class="small" for="menuSection">القسم الحالي</label>
+        <select id="menuSection"></select>
+        <div id="menuSectionStatus" class="drawer-note"></div>
+      </div>
       <div class="drawer-toggle">
         <span>الوضع الداكن</span>
         <button id="qtMode" type="button" aria-label="تبديل الوضع"></button>
@@ -480,6 +497,8 @@
     const pasteHint      = document.getElementById('pasteHint');
     const nearbyBox      = document.getElementById('nearbyBox');
     const nearbyList     = document.getElementById('nearbyList');
+    const headerSectionLabelEl = document.getElementById('headerSectionLabel');
+    const sectionChipEl        = document.getElementById('sectionChip');
 
     const resultsBox  = document.getElementById('resultsBox');
     const statusBadge = document.getElementById('statusBadge');
@@ -569,6 +588,11 @@ const advCard  = document.getElementById('advCard');
     const menuReloadBtn   = document.getElementById('menuReload');
     const menuHomeBtn     = document.getElementById('menuHome');
     const menuBulkBtn     = document.getElementById('menuBulk');
+    const menuSectionSelect = document.getElementById('menuSection');
+    const menuSectionStatus = document.getElementById('menuSectionStatus');
+    if (menuSectionStatus) {
+      menuSectionStatus.textContent = '✳️ اكتب اسم كل قسم في العمود K (بدءًا من K2) داخل ورقة Settings. يمكن أن يكون العنوان في K1 مثل Sheet_month_name أو أي وصف تفضله.';
+    }
     const viewTabs        = Array.from(document.querySelectorAll('.view-tab'));
     const mainViewEl      = document.getElementById('mainView');
     const bulkViewEl      = document.getElementById('bulkView');
@@ -604,6 +628,21 @@ const advCard  = document.getElementById('advCard');
     if (menuToggleBtn) menuToggleBtn.addEventListener('click', toggleDrawer);
     if (drawerCloseBtn) drawerCloseBtn.addEventListener('click', closeDrawer);
     if (drawerBackdrop) drawerBackdrop.addEventListener('click', closeDrawer);
+    if (menuSectionSelect) {
+      menuSectionSelect.addEventListener('change', () => {
+        const selected = menuSectionSelect.value;
+        if (!selected) return;
+        if (selected === activeSectionKey) {
+          if (activeSectionLabel) {
+            setSectionStatus('✅ القسم الحالي: ' + activeSectionLabel);
+          }
+          return;
+        }
+        performSectionSwitch(selected);
+      });
+    }
+    updateHeaderSectionUI('');
+    fetchSections();
 
     const viewsMap = { main: mainViewEl, bulk: bulkViewEl };
 
@@ -658,6 +697,12 @@ const advCard  = document.getElementById('advCard');
     let bulkPage = 1;
     let bulkMobileEnabled = false;
 
+    let sectionOptions = [];
+    let activeSectionKey = '';
+    let activeSectionLabel = '';
+    let manualSearchTimer = null;
+    let skipNextManualDebounce = false;
+
     const BULK_PAGE_SIZE = 20;
     const BULK_MOBILE_STORAGE_KEY = 'bulk_mobile_enabled';
     const JUST_COLORED_TTL = 120000;
@@ -698,16 +743,144 @@ const advCard  = document.getElementById('advCard');
       }
     }
 
-    const runServer = (fnName, ...args) => new Promise((resolve, reject) => {
-      try {
-        google.script.run
-          .withSuccessHandler(resolve)
-          .withFailureHandler(err => reject(err))
-          [fnName](...args);
-      } catch (err) {
-        reject(err);
+    function setSectionStatus(message){
+      if (menuSectionStatus) {
+        menuSectionStatus.textContent = message || '';
       }
-    });
+    }
+
+    function updateHeaderSectionUI(label){
+      const safe = String(label || '').trim();
+      window.__activeSectionLabel = safe;
+      if (headerSectionLabelEl) {
+        headerSectionLabelEl.textContent = safe || '—';
+      }
+      if (sectionChipEl) {
+        sectionChipEl.classList.toggle('is-empty', !safe);
+        sectionChipEl.title = safe ? `القسم الحالي: ${safe}` : 'لم يتم اختيار قسم';
+      }
+      if (window.__aiClient && typeof window.__aiClient.setActiveSection === 'function') {
+        window.__aiClient.setActiveSection(safe);
+      }
+    }
+
+    function rebuildSectionOptions(){
+      if (!menuSectionSelect) return;
+      const previous = menuSectionSelect.value;
+      menuSectionSelect.innerHTML = '';
+      sectionOptions.forEach(section => {
+        const opt = document.createElement('option');
+        opt.value = section.key || '';
+        opt.textContent = section.label || section.key || '';
+        menuSectionSelect.appendChild(opt);
+      });
+      const targetValue = activeSectionKey || previous;
+      if (targetValue) {
+        menuSectionSelect.value = targetValue;
+      }
+      if (!menuSectionSelect.value && menuSectionSelect.options.length) {
+        menuSectionSelect.selectedIndex = 0;
+      }
+      if (!activeSectionLabel && sectionOptions.length) {
+        const match = sectionOptions.find(s => s.key === menuSectionSelect.value);
+        activeSectionLabel = match ? match.label : '';
+      }
+      menuSectionSelect.disabled = sectionOptions.length <= 1;
+    }
+
+    async function fetchSections(options = {}){
+      if (!menuSectionSelect) return;
+      const keepStatus = options.keepStatus;
+      if (!keepStatus) setSectionStatus('⏳ جارٍ تحميل الأقسام…');
+      menuSectionSelect.disabled = true;
+      try {
+        const res = await runServer('getAvailableSections');
+        if (!res || res.ok === false) {
+          const msg = res?.message || 'فشل تحميل الأقسام.';
+          setSectionStatus('⚠️ ' + msg);
+          sectionOptions = [];
+          activeSectionKey = '';
+          activeSectionLabel = '';
+          menuSectionSelect.innerHTML = '';
+          menuSectionSelect.disabled = true;
+          return;
+        }
+        sectionOptions = Array.isArray(res.sections) ? res.sections : [];
+        activeSectionKey = res.activeKey || (sectionOptions[0]?.key || '');
+        const match = sectionOptions.find(s => s.key === activeSectionKey);
+        activeSectionLabel = res.activeLabel || (match ? match.label : '');
+        rebuildSectionOptions();
+        updateHeaderSectionUI(activeSectionLabel);
+        if (activeSectionLabel) {
+          setSectionStatus('✅ القسم الحالي: ' + activeSectionLabel);
+        } else {
+          setSectionStatus(sectionOptions.length ? 'اختر قسمًا لبدء العمل.' : 'لم يتم إعداد أي قسم.');
+        }
+      } catch (err) {
+        setSectionStatus('⚠️ حدث خطأ أثناء تحميل الأقسام: ' + (err?.message || err));
+        sectionOptions = [];
+        activeSectionKey = '';
+        activeSectionLabel = '';
+        menuSectionSelect.innerHTML = '';
+        menuSectionSelect.disabled = true;
+        updateHeaderSectionUI('');
+      }
+    }
+
+    async function performSectionSwitch(key){
+      const targetKey = String(key || '').trim();
+      if (!targetKey) return;
+      if (menuSectionSelect) menuSectionSelect.disabled = true;
+      setSectionStatus('⏳ جارٍ تحميل بيانات القسم…');
+      if (loadNote) loadNote.textContent = '⏳ جارٍ تحميل بيانات القسم…';
+      setLoadBtnState(false);
+      try {
+        const res = await runServer('switchActiveSection', targetKey);
+        if (!res || res.ok === false) {
+          const msg = res?.message || 'فشل تبديل القسم.';
+          setSectionStatus('⚠️ ' + msg);
+          if (loadNote) loadNote.textContent = '⚠️ ' + msg;
+          return;
+        }
+        activeSectionKey = res.section?.key || targetKey;
+        activeSectionLabel = res.section?.label || (sectionOptions.find(s => s.key === activeSectionKey)?.label || '');
+        rebuildSectionOptions();
+        updateHeaderSectionUI(activeSectionLabel);
+        const baseMsg = res.loadResult?.message || 'تم تحديث بيانات القسم.';
+        const serverOk = res.loadResult?.success !== false;
+        applyLoadResults(baseMsg, res.snapshot, { serverSuccess: serverOk });
+        if (activeSectionLabel) {
+          setSectionStatus('✅ القسم الحالي: ' + activeSectionLabel);
+        } else {
+          setSectionStatus('✅ تم تحديث القسم.');
+        }
+        if (typeof fillSheets === 'function') {
+          fillSheets();
+        } else {
+          refreshBulkSheets();
+        }
+      } catch (err) {
+        setSectionStatus('⚠️ حدث خطأ أثناء تحديث القسم: ' + (err?.message || err));
+      } finally {
+        if (menuSectionSelect) {
+          menuSectionSelect.disabled = sectionOptions.length <= 1;
+          menuSectionSelect.value = activeSectionKey || '';
+        }
+      }
+    }
+
+    function runServer(fnName, ...args) {
+      return new Promise((resolve, reject) => {
+        try {
+          google.script.run
+            .withSuccessHandler(resolve)
+            .withFailureHandler(err => reject(err))
+            [fnName](...args);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }
 
     const parseBulkIds = txt => {
       return String(txt || '')
@@ -800,7 +973,9 @@ const advCard  = document.getElementById('advCard');
         `;
         btn.addEventListener('click', () => {
           idInput.value = suggestion.id || '';
-          doSearch();
+          clearTimeout(manualSearchTimer);
+          manualSearchTimer = null;
+          doSearch({ allowSuggestions:true });
         });
         nearbyList.appendChild(btn);
       });
@@ -1354,7 +1529,9 @@ const advCard  = document.getElementById('advCard');
         const salaryVal = Number(baseSalaryRaw || 0);
         const salaryStr = salaryVal.toFixed(2);
         if (mode === 'salary') return salaryStr;
-        return [res.id || '', salaryStr, res.state || ''].join('\t');
+        const stateText = res.state || '';
+        const duplicateText = res.duplicateLabel ? `${stateText ? ' - ' : ''}${res.duplicateLabel}` : '';
+        return [res.id || '', salaryStr, `${stateText}${duplicateText}`.trim()].join('\t');
       });
       const text = rows.join('\n');
       const successMessage = copyingDuringRun
@@ -1470,7 +1647,9 @@ const advCard  = document.getElementById('advCard');
       const v = lastIdText.textContent || '';
       if (!v) return;
       idInput.value = v;
-      doSearch();
+      clearTimeout(manualSearchTimer);
+      manualSearchTimer = null;
+      doSearch({ manual:true, allowSuggestions:false });
     });
 
     /******** تحميل الأوراق ********/
@@ -1498,6 +1677,26 @@ const advCard  = document.getElementById('advCard');
       if (ok===true){ reloadBtn.classList.remove('btn-red'); reloadBtn.classList.add('btn-green'); }
       else if (ok===false){ reloadBtn.classList.remove('btn-green'); reloadBtn.classList.add('btn-red'); }
     }
+
+    function applyLoadResults(baseMessage, snapshot, options = {}){
+      if (!loadNote) return;
+      const baseMsg = baseMessage || 'تم التحميل من السيرفر.';
+      const serverOk = options.serverSuccess !== false;
+      if (!snapshot || snapshot.ok === false) {
+        const extra = snapshot && snapshot.message ? snapshot.message : '';
+        loadNote.textContent = extra
+          ? `${baseMsg} | ⚠️ فشل المحلي: ${extra}`
+          : `${baseMsg} | ⚠️ فشل التحميل المحلي.`;
+        setLoadBtnState(false);
+        return;
+      }
+      localMap = snapshot.map || null;
+      rebuildSortedLocalIds();
+      const st = snapshot.stats || {};
+      loadNote.textContent = `${baseMsg} | محلي: ${st.agentRows||0} صف / ${st.agentUnique||0} ID.`;
+      setLoadBtnState(serverOk);
+      refreshCountsLive();
+    }
     function loadData(){
       setLoadBtnState(false);
       loadNote.textContent = '⏳ جارٍ تحميل البيانات…';
@@ -1506,17 +1705,8 @@ const advCard  = document.getElementById('advCard');
           const baseMsg = srv?.message || 'تم التحميل من السيرفر.';
           google.script.run
             .withSuccessHandler(res=>{
-              if(!res || !res.ok){
-                loadNote.textContent = baseMsg + ' | ⚠️ فشل المحلي: ' + (res?.message||'');
-                setLoadBtnState(false);
-                return;
-              }
-              localMap = res.map || null;
-              rebuildSortedLocalIds();
-              const st = res.stats || {};
-              loadNote.textContent = `${baseMsg} | محلي: ${st.agentRows||0} صف / ${st.agentUnique||0} ID.`;
-              setLoadBtnState(true);
-              refreshCountsLive();
+              const serverOk = srv?.success !== false;
+              applyLoadResults(baseMsg, res, { serverSuccess: serverOk });
             })
             .withFailureHandler(err=>{
               loadNote.textContent = baseMsg + ' | ⚠️ خطأ بالمحلي: ' + (err?.message||'');
@@ -1626,19 +1816,53 @@ const advCard  = document.getElementById('advCard');
         const txt = await navigator.clipboard.readText();
         if (txt && txt.trim()){
           idInput.value = txt.trim();
-          doSearch();
+          clearTimeout(manualSearchTimer);
+          manualSearchTimer = null;
+          doSearch({ manual:true, allowSuggestions:false });
           return;
         }
       }catch(_){}
       idInput.focus(); idInput.select();
       pasteHint.textContent = 'الصق يدويًا وسيبدأ البحث تلقائيًا…';
-      const once = ()=>{ pasteHint.textContent = ''; idInput.removeEventListener('input', once); setTimeout(doSearch, 0); };
+      const once = ()=>{
+        pasteHint.textContent = '';
+        idInput.removeEventListener('input', once);
+        skipNextManualDebounce = true;
+        setTimeout(()=>{
+          doSearch({ manual:true, allowSuggestions:false });
+          skipNextManualDebounce = false;
+        }, 0);
+      };
       idInput.addEventListener('input', once, { once:true });
     });
-    idInput.addEventListener('paste', ()=> setTimeout(doSearch, 0));
-    idInput.addEventListener('keyup', e=>{ if (e.key === 'Enter') doSearch(); });
+    idInput.addEventListener('paste', ()=>{
+      skipNextManualDebounce = true;
+      setTimeout(()=>{
+        clearTimeout(manualSearchTimer);
+        manualSearchTimer = null;
+        doSearch({ manual:true, allowSuggestions:false });
+        skipNextManualDebounce = false;
+      }, 0);
+    });
+    idInput.addEventListener('keyup', e=>{
+      if (e.key === 'Enter'){
+        clearTimeout(manualSearchTimer);
+        manualSearchTimer = null;
+        doSearch({ manual:true, allowSuggestions:false });
+      }
+    });
     idInput.addEventListener('input', ()=>{
-      if (!idInput.value.trim()) clearNearbySuggestions();
+      if (skipNextManualDebounce) return;
+      const val = String(idInput.value || '').trim();
+      clearTimeout(manualSearchTimer);
+      if (!val){
+        manualSearchTimer = null;
+        doSearch({ manual:true, allowSuggestions:false });
+        return;
+      }
+      manualSearchTimer = setTimeout(()=>{
+        doSearch({ manual:true, allowSuggestions:false });
+      }, 140);
     });
 
     /******** رندر النتائج ********/
@@ -1992,8 +2216,9 @@ const advCard  = document.getElementById('advCard');
       };
     }
 
-  function doSearch(){
+  function doSearch(options = {}){
     const id = String(idInput.value||'').trim();
+    const allowSuggestions = options && options.allowSuggestions !== false;
     if (!id){
       applyBadges('غير موجود', null, false);
       amountText.textContent = '—';
@@ -2047,7 +2272,7 @@ const advCard  = document.getElementById('advCard');
       clearNearbySuggestions();
     }
     // إذا غير موجود محليًا (قد يكون "إدارة فقط"): لا نعرض "غير موجود" — ننتظر رد السيرفر.
-    else {
+    else if (allowSuggestions) {
       renderNearbySuggestions(id);
     }
 
@@ -2059,17 +2284,17 @@ const advCard  = document.getElementById('advCard');
         if (mySeq !== window.__qseq) return; // تجاهل الردود المتأخرة
         if (!res || res.status === 'error'){
           if (res && res.message) renderResult({ status:'error', message: res.message });
-          renderNearbySuggestions(id);
+          if (allowSuggestions) renderNearbySuggestions(id); else clearNearbySuggestions();
           return;
         }
         renderResult(res);
-        if (res.status === 'غير موجود') renderNearbySuggestions(id);
+        if (allowSuggestions && res.status === 'غير موجود') renderNearbySuggestions(id);
         else clearNearbySuggestions();
         renderPersonCard(id);
       })
       .withFailureHandler(err=>{
         if (err && err.message) renderResult({ status:'error', message: err.message });
-        renderNearbySuggestions(id);
+        if (allowSuggestions) renderNearbySuggestions(id); else clearNearbySuggestions();
       })
       .searchId(id, pct);
   }
@@ -2514,7 +2739,6 @@ const advCard  = document.getElementById('advCard');
 })();
 </script>
 <?!= HtmlService.createHtmlOutputFromFile('AIClient').getContent(); ?>
-</script>
 <!-- ✅ ترتيب موحّد + تثبيت الأدوات السريعة + تنسيق صف البحث -->
  
 <script>


### PR DESCRIPTION
## Summary
- unify the header counters into a compact cluster with the active section chip and refresh the nearby suggestion styling to match
- trigger manual ID lookups instantly without local suggestions while keeping the section selector and status chips in sync
- add an AI-backed ID suggestion service and client card that surfaces clickable recommendations styled for the current interface

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3591eebe08324bc7e98e90abc7b63