### PR TITLE
Fix mobile load card placement and round results container

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -90,7 +90,7 @@
     #mainView.view-panel{gap:24px;}
     #bulkView.view-panel{gap:24px;}
     @media(min-width:640px){.main-primary-grid{grid-template-columns:minmax(0,1.25fr) minmax(0,1fr);}}
-    #resultsBox{padding:26px 22px;text-align:center;background:radial-gradient(circle at top,#1a2e2a 0%,#0b1118 55%,#090d13 100%);border:1px solid rgba(43,255,168,.22);box-shadow:0 28px 70px rgba(30,255,168,.18);display:flex;flex-direction:column;gap:12px;justify-content:center;}
+    #resultsBox{padding:26px 22px;text-align:center;background:radial-gradient(circle at top,#1a2e2a 0%,#0b1118 55%,#090d13 100%);border:1px solid rgba(43,255,168,.22);box-shadow:0 28px 70px rgba(30,255,168,.18);display:flex;flex-direction:column;gap:12px;justify-content:center;border-radius:26px;}
     #resultsBox .badges{display:flex;justify-content:center;gap:8px;flex-wrap:wrap;margin-bottom:0;}
     #searchCard{background:linear-gradient(160deg,rgba(18,26,38,.94),rgba(7,12,22,.88));border-radius:22px;box-shadow:0 18px 42px rgba(6,10,20,.4);border:1px solid rgba(255,255,255,.05);display:flex;flex-direction:column;gap:16px;padding:22px 20px;}
     #searchCard button{min-width:160px;}
@@ -185,6 +185,13 @@
     @media(max-width:768px){
       #advCard .adv-control{gap:6px;padding:12px;}
       #advCard .adv-control--color input[type="color"]{height:52px;}
+    }
+
+    #mobileLoadCardSpot{display:none;margin-top:18px;justify-content:center;}
+    @media(max-width:768px){
+      #mobileLoadCardSpot{margin-top:24px;}
+      #mobileLoadCardSpot.show{display:flex;}
+      #mobileLoadCardSpot #loadCard{width:100%;max-width:420px;min-width:0;}
     }
 
     @media(min-width:1024px){
@@ -468,6 +475,7 @@
       </div>
     </section>
 
+    <div id="mobileLoadCardSpot"></div>
   </div>
 
   <div id="drawerBackdrop" class="drawer-backdrop"></div>
@@ -509,8 +517,40 @@
 
   <script>
     // عناصر عامة
+    const loadCard       = document.getElementById('loadCard');
     const reloadBtn      = document.getElementById('reloadBtn');
     const loadNote       = document.getElementById('loadNote');
+    const mobileLoadCardSpot = document.getElementById('mobileLoadCardSpot');
+    const loadCardHome = loadCard ? { parent: loadCard.parentNode, next: loadCard.nextSibling } : null;
+    const loadCardMedia = window.matchMedia('(max-width: 768px)');
+
+    function placeLoadCard(){
+      if (!loadCard || !loadCardHome || !loadCardHome.parent) return;
+      if (loadCardMedia.matches && mobileLoadCardSpot){
+        if (loadCard.parentNode !== mobileLoadCardSpot){
+          mobileLoadCardSpot.appendChild(loadCard);
+        }
+        mobileLoadCardSpot.classList.add('show');
+      } else {
+        if (loadCard.parentNode !== loadCardHome.parent){
+          if (loadCardHome.next && loadCardHome.next.parentNode === loadCardHome.parent){
+            loadCardHome.parent.insertBefore(loadCard, loadCardHome.next);
+          } else {
+            loadCardHome.parent.appendChild(loadCard);
+          }
+        }
+        if (mobileLoadCardSpot){
+          mobileLoadCardSpot.classList.remove('show');
+        }
+      }
+    }
+
+    placeLoadCard();
+    if (typeof loadCardMedia.addEventListener === 'function'){
+      loadCardMedia.addEventListener('change', placeLoadCard);
+    } else if (typeof loadCardMedia.addListener === 'function'){
+      loadCardMedia.addListener(placeLoadCard);
+    }
 
     const idInput        = document.getElementById('idInput');
     const pasteSearchBtn = document.getElementById('pasteSearchBtn');


### PR DESCRIPTION
## Summary
- keep the data loading card anchored at the bottom of the mobile layout while retaining the desktop placement
- round the primary results container to better match the page styling

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e47aead07083249b9a5ea6f21bcbd4