### PR TITLE
Refine Android layout and bulk search settings

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -139,8 +139,14 @@
     #bulkCard th,#bulkCard td{padding:10px;border-bottom:1px solid rgba(255,255,255,.05);text-align:right;}
     #bulkCard tbody tr:nth-child(even){background:rgba(255,255,255,.02);}
     #bulkCard .bulk-page-btn{background:var(--surface-strong);color:var(--text);border:1px solid rgba(255,255,255,.08);}
-    #bulkConfigCard{padding:28px;display:flex;flex-direction:column;gap:20px;}
+    #bulkConfigCard{padding:28px;display:flex;flex-direction:column;gap:18px;}
+    #bulkConfigCard .bulk-config-top{display:flex;flex-direction:column;gap:10px;}
+    #bulkConfigCard .bulk-config-title{margin:0;font-size:20px;color:var(--accent);}
+    #bulkConfigCard .bulk-config-sub{margin:0;color:var(--muted);font-size:13px;}
     .bulk-config-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;}
+    #bulkConfigCard .bulk-config-grid.primary{grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;}
+    #bulkConfigCard .bulk-config-body{display:flex;flex-direction:column;gap:16px;}
+    .bulk-config-grid.two{grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}
     .bulk-config-block,.bulk-color-chip{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:18px;padding:14px 16px;display:flex;flex-direction:column;gap:12px;}
     .bulk-color-chip{flex-direction:row;align-items:center;gap:12px;}
     .bulk-color-chip input{flex:0 0 auto;}
@@ -183,6 +189,31 @@
     #statusChipsRow{display:flex;flex-wrap:wrap;gap:6px;justify-content:center;}
     #statusChipsRow .chip{padding:4px 10px;border-radius:999px;background:rgba(255,255,255,.05);font-size:11px;color:var(--muted);}
     .view-panel footer{margin-top:8px;font-size:12px;color:var(--muted);text-align:center;}
+
+    body.android-ui #mainPrimaryCard{padding:26px 20px;gap:20px;}
+    body.android-ui #mainPrimaryCard .primary-interaction{gap:18px;}
+    body.android-ui .android-options-container{display:flex;flex-direction:column;gap:18px;background:linear-gradient(160deg,rgba(18,26,38,.92),rgba(8,12,22,.88));border-radius:22px;border:1px solid rgba(255,255,255,.05);padding:20px 18px;box-shadow:0 18px 42px rgba(6,10,20,.46);}
+    body.android-ui .android-options-container > *{width:100%;}
+    body.android-ui #searchCard{background:rgba(12,20,32,.95);border-radius:18px;border:1px solid rgba(255,255,255,.06);box-shadow:none;padding:18px 16px;}
+    body.android-ui #searchCard button{min-width:0;}
+    body.android-ui #searchCard .actions{flex-direction:column;align-items:flex-start;gap:10px;}
+    body.android-ui #advCard{background:rgba(255,255,255,.03);border-radius:18px;border:1px solid rgba(255,255,255,.05);box-shadow:none;padding:18px;gap:18px;}
+    body.android-ui #advCard .adv-top{gap:10px;}
+    body.android-ui #advCard .adv-control-grid{gap:12px;}
+    body.android-ui #advCard .adv-control{background:rgba(12,20,32,.72);border:1px solid rgba(255,255,255,.05);}
+    body.android-ui #advCard .row.stretch{flex-direction:column;gap:12px;}
+    body.android-ui #advCard .row.stretch>*,body.android-ui #advCard .row.stretch>button{width:100%;}
+    body.android-ui .primary-suggest-slot{margin-top:0;}
+    body.android-ui #aiMobileMountHost{display:none!important;}
+    body.android-ui .android-quick-ids{display:flex;flex-direction:column;gap:10px;padding:14px;border-radius:18px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.06);}
+    body.android-ui .android-quick-ids[hidden]{display:none;}
+    body.android-ui .android-quick-head{display:flex;flex-direction:column;gap:4px;}
+    body.android-ui .android-quick-title{font-size:15px;font-weight:800;color:var(--accent);}
+    body.android-ui .android-quick-sub{font-size:12px;color:var(--muted);}
+    body.android-ui .android-quick-list{display:flex;flex-wrap:wrap;gap:8px;}
+    body.android-ui .android-quick-chip{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:14px;background:var(--surface-strong);border:1px solid rgba(43,255,168,.22);color:var(--text);font-size:13px;font-weight:700;cursor:pointer;min-width:0;box-shadow:none;}
+    body.android-ui .android-quick-chip::before{content:'#';color:var(--accent);font-weight:800;}
+    body.android-ui .android-quick-chip:active{transform:scale(.97);}
 
     #advCard .adv-control .title{display:none;}
     @media(max-width:768px){
@@ -358,6 +389,69 @@
     </section>
 
     <section id="bulkView" class="view-panel">
+      <div class="card" id="bulkConfigCard">
+        <div class="bulk-config-top">
+          <h3 class="bulk-config-title">إعدادات البحث</h3>
+          <p class="bulk-config-sub">اختر النطاق وورقة الهدف قبل البدء بالتحليل.</p>
+          <div class="bulk-config-grid primary">
+            <div class="bulk-config-block">
+              <label class="small">النطاق</label>
+              <select id="bulkScope">
+                <option value="agent">الوكيل فقط</option>
+                <option value="both" selected>الإدارة + الوكيل</option>
+                <option value="all">الكل (يشمل الخارجي)</option>
+              </select>
+            </div>
+            <div class="bulk-config-block">
+              <label class="small">ورقة الهدف</label>
+              <div class="row" style="gap:6px; align-items:center">
+                <select id="bulkTargetSheet" style="flex:1"></select>
+                <button id="bulkRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق" style="flex:0 0 auto">↻</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="bulk-config-body">
+          <div class="bulk-inline">
+            <input id="bulkNewSheet" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
+            <button id="bulkCreateSheet" class="btn-ghost">إنشاء ورقة</button>
+          </div>
+
+          <div id="bulkExternalWrap" class="bulk-external" style="display:none">
+            <label class="small" style="display:block">ورقة الهدف (خارجي) <span id="bulkExternalFileLabel" class="muted"></span></label>
+            <div class="row" style="gap:6px; align-items:center">
+              <select id="bulkExternalTargetSheet" style="flex:1"></select>
+              <button id="bulkExternalRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق الخارجية" style="flex:0 0 auto">↻</button>
+            </div>
+            <div class="row stretch" style="margin-top:8px">
+              <input id="bulkExternalNewSheet" type="text" placeholder="اسم ورقة جديدة (خارجية)">
+              <button id="bulkExternalCreateSheet" class="btn-ghost">إنشاء</button>
+            </div>
+            <div id="bulkExternalNote" class="muted" style="margin-top:6px"></div>
+          </div>
+
+          <div class="bulk-config-grid two">
+            <div class="bulk-color-chip">
+              <input id="bulkAdminColor" type="color" value="#fde68a" style="width:38px;height:32px;border:1px solid var(--border);border-radius:8px;padding:0" />
+              <label class="small" style="margin:0">لون الإدارة</label>
+            </div>
+            <div class="bulk-color-chip">
+              <input id="bulkWithdrawColor" type="color" value="#9629ff" style="width:38px;height:32px;border:1px solid var(--border);border-radius:8px;padding:0" />
+              <label class="small" style="margin:0">لون الوكيل / سحب الوكالة</label>
+            </div>
+          </div>
+
+          <div class="bulk-discount-row">
+            <div class="row" style="gap:8px; align-items:center">
+              <label class="small" style="margin:0">الخصم %</label>
+              <input id="bulkDiscount" type="number" min="0" max="100" value="0" step="1" style="width:110px">
+            </div>
+            <div class="muted" id="bulkDiscountNote">يُطبّق تلقائيًا على النتائج.</div>
+          </div>
+        </div>
+      </div>
+
       <div class="card" id="bulkCard">
         <div class="bulk-header">
           <h3>أداة البحث الجماعي</h3>
@@ -413,63 +507,6 @@
           <div id="bulkEmptyState" class="bulk-empty">لا توجد نتائج بعد.</div>
         </div>
       </div>
-
-      <div class="card" id="bulkConfigCard">
-        <div class="bulk-config-grid">
-          <div class="bulk-config-block">
-            <label class="small">النطاق</label>
-            <select id="bulkScope">
-              <option value="agent">الوكيل فقط</option>
-              <option value="both" selected>الإدارة + الوكيل</option>
-              <option value="all">الكل (يشمل الخارجي)</option>
-            </select>
-          </div>
-          <div class="bulk-config-block">
-            <label class="small">ورقة الهدف</label>
-            <div class="row" style="gap:6px; align-items:center">
-              <select id="bulkTargetSheet" style="flex:1"></select>
-              <button id="bulkRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق" style="flex:0 0 auto">↻</button>
-            </div>
-          </div>
-        </div>
-
-        <div class="bulk-inline">
-          <input id="bulkNewSheet" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
-          <button id="bulkCreateSheet" class="btn-ghost">إنشاء ورقة</button>
-        </div>
-
-        <div id="bulkExternalWrap" class="bulk-external" style="display:none">
-          <label class="small" style="display:block">ورقة الهدف (خارجي) <span id="bulkExternalFileLabel" class="muted"></span></label>
-          <div class="row" style="gap:6px; align-items:center">
-            <select id="bulkExternalTargetSheet" style="flex:1"></select>
-            <button id="bulkExternalRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق الخارجية" style="flex:0 0 auto">↻</button>
-          </div>
-          <div class="row stretch" style="margin-top:8px">
-            <input id="bulkExternalNewSheet" type="text" placeholder="اسم ورقة جديدة (خارجية)">
-            <button id="bulkExternalCreateSheet" class="btn-ghost">إنشاء</button>
-          </div>
-          <div id="bulkExternalNote" class="muted" style="margin-top:6px"></div>
-        </div>
-
-        <div class="bulk-config-grid two">
-          <div class="bulk-color-chip">
-            <input id="bulkAdminColor" type="color" value="#fde68a" style="width:38px;height:32px;border:1px solid var(--border);border-radius:8px;padding:0" />
-            <label class="small" style="margin:0">لون الإدارة</label>
-          </div>
-          <div class="bulk-color-chip">
-            <input id="bulkWithdrawColor" type="color" value="#9629ff" style="width:38px;height:32px;border:1px solid var(--border);border-radius:8px;padding:0" />
-            <label class="small" style="margin:0">لون الوكيل / سحب الوكالة</label>
-          </div>
-        </div>
-
-        <div class="bulk-discount-row">
-          <div class="row" style="gap:8px; align-items:center">
-            <label class="small" style="margin:0">الخصم %</label>
-            <input id="bulkDiscount" type="number" min="0" max="100" value="0" step="1" style="width:110px">
-          </div>
-          <div class="muted" id="bulkDiscountNote">يُطبّق تلقائيًا على النتائج.</div>
-        </div>
-      </div>
     </section>
 
     <div id="mobileLoadCardSpot"></div>
@@ -513,6 +550,95 @@
   </aside>
 
   <script>
+    const isAndroidDevice = /Android/i.test(navigator.userAgent || '');
+    if (isAndroidDevice) document.body.classList.add('android-ui');
+
+    const ANDROID_RECENT_KEY = 'android_recent_ids';
+    let androidRecentIds = [];
+    let androidQuickIdsEl = null;
+    let androidQuickIdsListEl = null;
+    let lastProfileIds = [];
+
+    function loadAndroidRecentIds(){
+      if (!isAndroidDevice) return [];
+      try {
+        const raw = localStorage.getItem(ANDROID_RECENT_KEY);
+        const arr = raw ? JSON.parse(raw) : [];
+        if (!Array.isArray(arr)) return [];
+        return arr.map(v => String(v || '').trim()).filter(Boolean);
+      } catch (_) {
+        return [];
+      }
+    }
+
+    function updateAndroidQuickIds(){
+      if (!isAndroidDevice || !androidQuickIdsEl || !androidQuickIdsListEl) return;
+      const seen = new Set();
+      const suggestions = [];
+      lastProfileIds.forEach(id => {
+        const value = String(id || '').trim();
+        if (value && !seen.has(value)){
+          seen.add(value);
+          suggestions.push(value);
+        }
+      });
+      androidRecentIds.forEach(id => {
+        const value = String(id || '').trim();
+        if (value && !seen.has(value)){
+          seen.add(value);
+          suggestions.push(value);
+        }
+      });
+      androidQuickIdsListEl.innerHTML = '';
+      if (!suggestions.length){
+        androidQuickIdsEl.hidden = true;
+        return;
+      }
+      androidQuickIdsEl.hidden = false;
+      const idInputEl = document.getElementById('idInput');
+      suggestions.slice(0,6).forEach(value => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'android-quick-chip';
+        btn.textContent = value;
+        btn.addEventListener('click', () => {
+          if (idInputEl) idInputEl.value = value;
+          try { clearTimeout(manualSearchTimer); manualSearchTimer = null; } catch(_) {}
+          doSearch({ manual:true });
+        });
+        androidQuickIdsListEl.appendChild(btn);
+      });
+    }
+
+    function setupAndroidLayout(){
+      if (!isAndroidDevice) return;
+      if (document.getElementById('androidOptionsContainer')) return;
+      const mainCard = document.getElementById('mainPrimaryCard');
+      const searchCardEl = document.getElementById('searchCard');
+      const advCardEl = document.getElementById('advCard');
+      const aiSlot = document.getElementById('aiMountHere');
+      if (!mainCard || !searchCardEl || !advCardEl || !aiSlot) return;
+      const container = document.createElement('div');
+      container.id = 'androidOptionsContainer';
+      container.className = 'android-options-container';
+      container.appendChild(searchCardEl);
+      const quickSection = document.createElement('section');
+      quickSection.id = 'androidQuickIds';
+      quickSection.className = 'android-quick-ids';
+      quickSection.innerHTML = '<div class="android-quick-head"><div class="android-quick-title">مقترحات IDs</div><div class="android-quick-sub">يعتمد على آخر النتائج والبحث اليدوي.</div></div><div class="android-quick-list"></div>';
+      quickSection.hidden = true;
+      androidQuickIdsEl = quickSection;
+      androidQuickIdsListEl = quickSection.querySelector('.android-quick-list');
+      container.appendChild(quickSection);
+      container.appendChild(advCardEl);
+      container.appendChild(aiSlot);
+      mainCard.appendChild(container);
+      androidRecentIds = loadAndroidRecentIds();
+      updateAndroidQuickIds();
+    }
+
+    if (isAndroidDevice) setupAndroidLayout();
+
     // عناصر عامة
     const loadCard       = document.getElementById('loadCard');
     const reloadBtn      = document.getElementById('reloadBtn');
@@ -556,6 +682,13 @@
 
     function placeAiSuggestions(){
       if (!aiMountSlot || !aiMountHome || !aiMountHome.parent) return;
+      if (isAndroidDevice){
+        const androidHost = document.getElementById('androidOptionsContainer');
+        if (androidHost && aiMountSlot.parentNode !== androidHost){
+          androidHost.appendChild(aiMountSlot);
+        }
+        return;
+      }
       if (aiMobileMedia.matches && aiMobileMount){
         if (aiMountSlot.parentNode !== aiMobileMount){
           aiMobileMount.appendChild(aiMountSlot);
@@ -767,7 +900,6 @@
     // حالة
     let localMap = null;
     let lastResult = null;
-    let lastProfileIds = [];
     let lastBaseId = '';
 
     let bulkIds = [];
@@ -1597,6 +1729,24 @@
       try { localStorage.setItem('last_id', id); } catch(_){}
       lastIdText.textContent = id || '';
       lastIdPill.style.display = id ? 'inline-flex' : 'none';
+      if (isAndroidDevice){
+        const value = String(id || '').trim();
+        if (value){
+          let stored = [];
+          try {
+            const raw = localStorage.getItem(ANDROID_RECENT_KEY);
+            const parsed = raw ? JSON.parse(raw) : [];
+            stored = Array.isArray(parsed) ? parsed : [];
+          } catch(_) { stored = []; }
+          const next = [value, ...stored.filter(x => String(x || '').trim() !== value)]
+            .map(x => String(x || '').trim())
+            .filter(Boolean)
+            .slice(0,6);
+          androidRecentIds = next;
+          try { localStorage.setItem(ANDROID_RECENT_KEY, JSON.stringify(next)); } catch(_) {}
+        }
+        updateAndroidQuickIds();
+      }
     }
     function loadLastId(){
       let v = '';
@@ -1965,6 +2115,7 @@
       personNote.textContent = 'جاري جلب الرسالة...';
       personMsg.value = '';
       lastProfileIds = [];
+      if (isAndroidDevice) updateAndroidQuickIds();
       google.script.run
         .withSuccessHandler(card=>{
           if(!card || !card.ok){
@@ -1973,6 +2124,7 @@
             return;
           }
           lastProfileIds = (card.ids||[]).map(x=> String(x.id));
+          if (isAndroidDevice) updateAndroidQuickIds();
           const txt = buildMessageText(card, applyDiscountToMessage.checked, localMap);
           personMsg.value = txt;
           personNote.textContent = `تم — عدد IDs: ${lastProfileIds.length}`;


### PR DESCRIPTION
## Summary
- merge the Android homepage controls into a single container with refreshed styling and quick ID suggestion chips backed by recent searches
- keep AI suggestions within the Android container while preserving desktop behavior
- move the bulk search scope/target configuration card above the tool with a clearer layout for the remaining options

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5033f26f083248fcf46f12f7fd0c8